### PR TITLE
`list_images()` doesn't work if path contains brackets.

### DIFF
--- a/nunif/utils/image_loader.py
+++ b/nunif/utils/image_loader.py
@@ -29,8 +29,11 @@ def image_load_task(q, stop_flag, files, max_queue_size, load_func):
 
 
 def list_images(directory, extentions=IMG_EXTENSIONS):
-    return sorted([f for f in glob.glob(os.path.join(directory, "*"))
-                   if os.path.splitext(f)[-1].lower() in extentions])
+    return sorted(
+        os.path.join(directory, f)
+        for f in os.listdir(directory)
+        if os.path.splitext(f)[-1].lower() in extentions
+    )
 
 
 class ImageLoader():


### PR DESCRIPTION
As [doc](https://docs.python.org/3.4/library/glob.html#glob.escape) said: path should be escaped before pass to `glob()`.

`list_images()` is really simple and `os.listdir()` is enough, so I've replaced `glob()` with `os.listdir()`