### PR TITLE
iw3: Reduce VRAM usage in process_video_full() when Lookahead Buffer Size is large

### DIFF
--- a/iw3/utils.py
+++ b/iw3/utils.py
@@ -574,8 +574,10 @@ def bind_batch_frame_callback(depth_model, side_model, segment_pts, args):
             else:
                 left_eyes, right_eyes = apply_divergence(depths, x_srcs, args, side_model)
 
-            results += [postprocess_image(left_eyes[i], right_eyes[i], args)
-                        for i in range(left_eyes.shape[0])]
+            frames = [postprocess_image(left_eyes[i], right_eyes[i], args)
+                      for i in range(left_eyes.shape[0])]
+            results += [VU.to_frame(frame) for frame in frames]
+
         return results
 
     def _batch_frame_callback(x, pts, flush):
@@ -634,7 +636,7 @@ def bind_vda_frame_callback(depth_model, side_model, segment_pts, args):
                 _, pts = src_queue.pop(0)
                 if pts in segment_pts:
                     out[0, 0:8, :] = 1.0
-                results.append(out)
+                results.append(VU.to_frame(out))
         else:
             for depths in chunks(depth_list, args.batch_size):
                 depths = torch.stack(depths)
@@ -644,8 +646,9 @@ def bind_vda_frame_callback(depth_model, side_model, segment_pts, args):
                     left_eyes, right_eyes = apply_rgbd(x_srcs, depths, mapper=args.mapper)
                 else:
                     left_eyes, right_eyes = apply_divergence(depths, x_srcs, args, side_model)
-                results += [postprocess_image(left_eyes[i], right_eyes[i], args)
-                            for i in range(left_eyes.shape[0])]
+                frames = [postprocess_image(left_eyes[i], right_eyes[i], args)
+                          for i in range(left_eyes.shape[0])]
+                results += [VU.to_frame(frame) for frame in frames]
         return results
 
     def _batch_infer():

--- a/nunif/utils/video.py
+++ b/nunif/utils/video.py
@@ -12,6 +12,7 @@ import torch
 from concurrent.futures import ThreadPoolExecutor
 from fractions import Fraction
 import time
+import numpy as np
 
 
 # Add video mimetypes that does not exist in mimetypes
@@ -164,12 +165,22 @@ def to_tensor(frame, device=None):
 
 def from_tensor(x):
     x = (x.permute(1, 2, 0).contiguous() * 255.0).to(torch.uint8).detach().cpu().numpy()
+    return from_ndarray(x)
+
+
+def from_ndarray(x):
     return av.video.frame.VideoFrame.from_ndarray(x, format="rgb24")
 
 
 def to_frame(x):
     if torch.is_tensor(x):
+        # float CHW
         return from_tensor(x)
+    elif isinstance(x, np.ndarray):
+        # uint8 HWC
+        return from_ndarray(x)
+    elif isinstance(x, av.video.frame.VideoFrame):
+        return x
     else:
         return from_image(x)
 


### PR DESCRIPTION
This PR dramatically reduces peak VRAM usage when Lookahead Buffer Size is large.
Before, all buffer_size SBS highres frames were held in VRAM. Now it is limited to batch_size.
Maybe fix #418 and #413
