### PR TITLE
High bit depth video (yuv420p10le) support

### DIFF
--- a/iw3/utils.py
+++ b/iw3/utils.py
@@ -1792,7 +1792,9 @@ def create_parser(required_true=True):
     # TODO: Change the default value from "unspecified" to "auto"
     parser.add_argument("--colorspace", type=str, default="unspecified",
                         choices=["unspecified", "auto",
-                                 "bt709", "bt709-pc", "bt709-tv", "bt601", "bt601-pc", "bt601-tv"],
+                                 "bt709", "bt709-pc", "bt709-tv",
+                                 "bt601", "bt601-pc", "bt601-tv",
+                                 "bt2020-tv", "bt2020-pq-tv"],
                         help="video colorspace")
     # Deprecated
     parser.add_argument("--zoed-batch-size", type=int,

--- a/iw3/utils.py
+++ b/iw3/utils.py
@@ -52,7 +52,7 @@ def chunks(array, n):
 def to_pil_image(x):
     # x is already clipped to 0-1
     assert x.dtype in {torch.float32, torch.float16}
-    x = TF.to_pil_image((x * 255).round_().to(torch.uint8).cpu())
+    x = TF.to_pil_image((x * 255).round().to(torch.uint8).cpu())
     return x
 
 
@@ -699,7 +699,7 @@ def bind_vda_frame_callback(depth_model, side_model, segment_pts, args):
         x = x / pix_max
         if args.max_output_height is not None or args.rotate_right or args.rotate_left:
             x = preprocess_image(x, args)
-            x_srcs = torch.clamp(x.permute(0, 2, 3, 1) * pix_max, 0, pix_max).to(pix_dtype).cpu()
+            x_srcs = (x.permute(0, 2, 3, 1) * pix_max).round().clamp(0, pix_max).to(pix_dtype).cpu()
         else:
             x_srcs = batch_queue
 
@@ -1182,7 +1182,7 @@ def bind_export_vda_frame_callback(depth_model, segment_pts, rgb_dir, depth_dir,
         x = torch.stack(batch_queue).to(args.state["device"]).permute(0, 3, 1, 2) / 255.0
         if args.max_output_height is not None or args.rotate_right or args.rotate_left:
             x = preprocess_image(x, args)
-            x_srcs = torch.clamp(x.permute(0, 2, 3, 1) * 255.0, 0, 255).to(torch.uint8).cpu()
+            x_srcs = (x.permute(0, 2, 3, 1) * 255.0).round().clamp(0, 255).to(torch.uint8).cpu()
         else:
             x_srcs = batch_queue
 

--- a/iw3/utils.py
+++ b/iw3/utils.py
@@ -1734,7 +1734,7 @@ def create_parser(required_true=True):
     parser.add_argument("--rgbd", action="store_true", help="output in RGBD")
     parser.add_argument("--half-rgbd", action="store_true", help="output in Half RGBD")
 
-    parser.add_argument("--pix-fmt", type=str, default="yuv420p", choices=["yuv420p", "yuv444p", "rgb24", "gbrp", "yuv420p10le"],
+    parser.add_argument("--pix-fmt", type=str, default="yuv420p", choices=["yuv420p", "yuv444p", "yuv420p10le", "rgb24", "gbrp", "gbrp10le", "gbrp16le"],
                         help="pixel format (video only)")
     parser.add_argument("--tta", action="store_true",
                         help="Use flip augmentation on depth model")

--- a/iw3/utils.py
+++ b/iw3/utils.py
@@ -1657,7 +1657,8 @@ def create_parser(required_true=True):
                         help="bitrate option for libopenh264")
     parser.add_argument("--preset", type=str, default="ultrafast",
                         choices=["ultrafast", "superfast", "veryfast", "faster", "fast",
-                                 "medium", "slow", "slower", "veryslow", "placebo"],
+                                 "medium", "slow", "slower", "veryslow", "placebo",
+                                 "p1", "p2", "p3", "p4", "p5", "p6", "p7"],
                         help="encoder preset option for video")
     parser.add_argument("--tune", type=str, nargs="+", default=[],
                         choices=["film", "animation", "grain", "stillimage", "psnr",

--- a/nunif/gui/video_encoding_box.py
+++ b/nunif/gui/video_encoding_box.py
@@ -32,7 +32,7 @@ CODEC_PIX_FMT = {
 
 
 def get_pix_fmt(codec):
-    return CODEC_PIX_FMT.get(codec, CODEC_ALL)
+    return CODEC_PIX_FMT.get(codec, PIX_FMT_ALL)
 
 
 def empty_translate_function(s):

--- a/nunif/gui/video_encoding_box.py
+++ b/nunif/gui/video_encoding_box.py
@@ -66,7 +66,10 @@ class VideoEncodingBox():
         self.lbl_colorspace = wx.StaticText(self.grp_video, label=T("Colorspace"))
         self.cbo_colorspace = wx.ComboBox(
             self.grp_video,
-            choices=["auto", "unspecified", "bt709", "bt709-pc", "bt709-tv", "bt601", "bt601-pc", "bt601-tv"],
+            choices=["auto", "unspecified",
+                     "bt709", "bt709-pc", "bt709-tv",
+                     "bt601", "bt601-pc", "bt601-tv",
+                     "bt2020-tv", "bt2020-pq-tv"],
             name=f"{prefix}cbo_colorspace")
         self.cbo_colorspace.SetEditable(False)
         self.cbo_colorspace.SetSelection(1)

--- a/nunif/gui/video_encoding_box.py
+++ b/nunif/gui/video_encoding_box.py
@@ -80,8 +80,7 @@ class VideoEncodingBox():
             self.grp_video,
             choices=["auto", "unspecified",
                      "bt709", "bt709-pc", "bt709-tv",
-                     "bt601", "bt601-pc", "bt601-tv",
-                     "bt2020-tv", "bt2020-pq-tv"],
+                     "bt601", "bt601-pc", "bt601-tv"],
             name=f"{prefix}cbo_colorspace")
         self.cbo_colorspace.SetEditable(False)
         self.cbo_colorspace.SetSelection(0)

--- a/nunif/gui/video_encoding_box.py
+++ b/nunif/gui/video_encoding_box.py
@@ -9,13 +9,14 @@ LEVEL_ALL = ["auto"] + sorted(list(set(LEVEL_LIBX264) | set(LEVEL_LIBX265)), key
 TUNE_LIBX264 = ["film", "animation", "grain", "stillimage", "psnr"]
 TUNE_LIBX265 = ["grain", "animation", "psnr", "fastdecode", "zerolatency"]
 TUNE_NVENC = ["hq", "ll", "ull"]
-TUNE_ALL = [""] + sorted(list(set(TUNE_LIBX264) | set(TUNE_LIBX265)))
+TUNE_ALL = [""] + list(dict.fromkeys(TUNE_LIBX264 + TUNE_LIBX265 + TUNE_NVENC))
 
 PRESET_LIBX264 = ["ultrafast", "superfast", "veryfast", "faster", "fast",
                   "medium", "slow", "slower", "veryslow", "placebo"]
 PRESET_NVENC = ["fast", "medium", "slow",
                 "p1", "p2", "p3", "p4", "p5", "p6", "p7"]
-PRESET_ALL = PRESET_LIBX264
+
+PRESET_ALL = list(dict.fromkeys(PRESET_LIBX264 + PRESET_NVENC))
 
 CODEC_ALL = ["libx264", "libopenh264", "libx265", "h264_nvenc", "hevc_nvenc", "utvideo", "ffv1"]
 

--- a/nunif/gui/video_encoding_box.py
+++ b/nunif/gui/video_encoding_box.py
@@ -83,7 +83,7 @@ class VideoEncodingBox():
                      "bt2020-tv", "bt2020-pq-tv"],
             name=f"{prefix}cbo_colorspace")
         self.cbo_colorspace.SetEditable(False)
-        self.cbo_colorspace.SetSelection(1)
+        self.cbo_colorspace.SetSelection(0)
 
         self.lbl_crf = wx.StaticText(self.grp_video, label=T("CRF"))
         self.cbo_crf = EditableComboBox(self.grp_video, choices=[str(n) for n in range(16, 28)],

--- a/nunif/gui/video_encoding_box.py
+++ b/nunif/gui/video_encoding_box.py
@@ -18,8 +18,9 @@ PRESET_ALL = PRESET_LIBX264
 
 CODEC_ALL = ["libx264", "libopenh264", "libx265", "h264_nvenc", "hevc_nvenc", "utvideo"]
 
-PIX_FMT_ALL = ["yuv420p", "yuv444p", "rgb24"]
+PIX_FMT_ALL = ["yuv420p", "yuv444p", "yuv420p10le", "rgb24"]
 PIX_FMT_OPEN_H264 = ["yuv420p"]
+PIX_FMT_UTVIDEO = ["yuv420p", "yuv444p", "rgb24"]
 
 
 def empty_translate_function(s):
@@ -279,6 +280,8 @@ class VideoEncodingBox():
         user_pix_fmt = self.cbo_pix_fmt.GetValue()
         if codec == "libopenh264":
             choices = PIX_FMT_OPEN_H264
+        elif codec == "utvideo":
+            choices = PIX_FMT_UTVIDEO
         else:
             choices = PIX_FMT_ALL
         self.cbo_pix_fmt.SetItems(choices)

--- a/nunif/gui/video_encoding_box.py
+++ b/nunif/gui/video_encoding_box.py
@@ -13,7 +13,8 @@ TUNE_ALL = [""] + sorted(list(set(TUNE_LIBX264) | set(TUNE_LIBX265)))
 
 PRESET_LIBX264 = ["ultrafast", "superfast", "veryfast", "faster", "fast",
                   "medium", "slow", "slower", "veryslow", "placebo"]
-PRESET_NVENC = ["fast", "medium", "slow"]
+PRESET_NVENC = ["fast", "medium", "slow",
+                "p1", "p2", "p3", "p4", "p5", "p6", "p7"]
 PRESET_ALL = PRESET_LIBX264
 
 CODEC_ALL = ["libx264", "libopenh264", "libx265", "h264_nvenc", "hevc_nvenc", "utvideo", "ffv1"]

--- a/nunif/utils/video.py
+++ b/nunif/utils/video.py
@@ -214,7 +214,10 @@ def to_frame(x, use_16bit=False):
 def pix_fmt_requires_16bit(pix_fmt):
     return pix_fmt in {
         "yuv420p10le", "p010le",
-        "gbrp16le", "gbrp10le", "rgb48le"
+        "yuv422p10le", "yuv444p10le",
+        "yuv420p12le", "yuv422p12le", "yuv444p12le",
+        "yuv444p16le",
+        "gbrp16le", "gbrp12le", "gbrp10le", "rgb48le",
     }
 
 
@@ -703,6 +706,10 @@ def configure_video_codec(config):
         elif config.colorspace in {"bt2020", "bt2020-pc", "bt2020-tv", "bt2020-pq-tv", "auto", "copy"}:
             # not supported
             config.colorspace = "bt709-tv"
+
+    if config.video_codec == "ffv1":
+        if config.pix_fmt == "rgb24":
+            config.pix_fmt = "bgr0"
 
     if config.video_codec == "libx264":
         if config.pix_fmt in {"rgb24", "gbrp"}:

--- a/stlizer/main.py
+++ b/stlizer/main.py
@@ -68,7 +68,9 @@ def create_parser(required_true=True):
     # TODO: Change the default value from "unspecified" to "auto"
     parser.add_argument("--colorspace", type=str, default="unspecified",
                         choices=["unspecified", "auto",
-                                 "bt709", "bt709-pc", "bt709-tv", "bt601", "bt601-pc", "bt601-tv"],
+                                 "bt709", "bt709-pc", "bt709-tv",
+                                 "bt601", "bt601-pc", "bt601-tv",
+                                 "bt2020-tv", "bt2020-pq-tv"],
                         help="video colorspace")
 
     return parser

--- a/stlizer/main.py
+++ b/stlizer/main.py
@@ -46,14 +46,16 @@ def create_parser(required_true=True):
 
     parser.add_argument("--max-fps", type=float, default=60.0,
                         help="max framerate for video. output fps = min(fps, --max-fps)")
-    parser.add_argument("--pix-fmt", type=str, default="yuv420p", choices=["yuv420p", "yuv444p", "yuv420p10le", "rgb24", "gbrp", "gbrp10le", "gbrp16le"],
+    parser.add_argument("--pix-fmt", type=str, default="yuv420p",
+                        choices=["yuv420p", "yuv444p", "yuv420p10le", "rgb24", "gbrp", "gbrp10le", "gbrp16le"],
                         help="pixel format")
     parser.add_argument("--profile-level", type=str, help="h264 profile level")
     parser.add_argument("--crf", type=int, default=20,
                         help="constant quality value for video. smaller value is higher quality")
     parser.add_argument("--preset", type=str, default="medium",
                         choices=["ultrafast", "superfast", "veryfast", "faster", "fast",
-                                 "medium", "slow", "slower", "veryslow", "placebo"],
+                                 "medium", "slow", "slower", "veryslow", "placebo",
+                                 "p1", "p2", "p3", "p4", "p5", "p6", "p7"],
                         help="encoder preset option for video")
     parser.add_argument("--tune", type=str, nargs="+", default=[],
                         choices=["film", "animation", "grain", "stillimage", "psnr",

--- a/stlizer/main.py
+++ b/stlizer/main.py
@@ -46,7 +46,7 @@ def create_parser(required_true=True):
 
     parser.add_argument("--max-fps", type=float, default=60.0,
                         help="max framerate for video. output fps = min(fps, --max-fps)")
-    parser.add_argument("--pix-fmt", type=str, default="yuv420p", choices=["yuv420p", "yuv444p", "rgb24", "gbrp", "yuv420p10le"],
+    parser.add_argument("--pix-fmt", type=str, default="yuv420p", choices=["yuv420p", "yuv444p", "yuv420p10le", "rgb24", "gbrp", "gbrp10le", "gbrp16le"],
                         help="pixel format")
     parser.add_argument("--profile-level", type=str, help="h264 profile level")
     parser.add_argument("--crf", type=int, default=20,

--- a/stlizer/main.py
+++ b/stlizer/main.py
@@ -46,7 +46,7 @@ def create_parser(required_true=True):
 
     parser.add_argument("--max-fps", type=float, default=60.0,
                         help="max framerate for video. output fps = min(fps, --max-fps)")
-    parser.add_argument("--pix-fmt", type=str, default="yuv420p", choices=["yuv420p", "yuv444p", "rgb24", "gbrp"],
+    parser.add_argument("--pix-fmt", type=str, default="yuv420p", choices=["yuv420p", "yuv444p", "rgb24", "gbrp", "yuv420p10le"],
                         help="pixel format")
     parser.add_argument("--profile-level", type=str, help="h264 profile level")
     parser.add_argument("--crf", type=int, default=20,

--- a/stlizer/multipass_pipeline.py
+++ b/stlizer/multipass_pipeline.py
@@ -370,7 +370,7 @@ def outpaint(x, mask, model, device, composite):
 
 def pass4(output_path, shift_x_fix, shift_y_fix, angle_fix, transforms, scene_weight, fps, args):
     device = args.state["device"]
-    use_16bit = args.pix_fmt in {"yuv420p10le"}
+    use_16bit = VU.pix_fmt_requires_16bit(args.pix_fmt)
 
     if args.border in {"outpaint", "expand_outpaint"}:
         with TorchHubDir(TORCH_HUB_DIR):

--- a/stlizer/multipass_pipeline.py
+++ b/stlizer/multipass_pipeline.py
@@ -370,6 +370,7 @@ def outpaint(x, mask, model, device, composite):
 
 def pass4(output_path, shift_x_fix, shift_y_fix, angle_fix, transforms, scene_weight, fps, args):
     device = args.state["device"]
+    use_16bit = args.pix_fmt in {"yuv420p10le"}
 
     if args.border in {"outpaint", "expand_outpaint"}:
         with TorchHubDir(TORCH_HUB_DIR):
@@ -381,8 +382,7 @@ def pass4(output_path, shift_x_fix, shift_y_fix, angle_fix, transforms, scene_we
     def test_callback(frame):
         if frame is None:
             return None
-        im = frame.to_image()
-        x = TF.to_tensor(im).to(device)
+        x = VU.to_tensor(frame, device=device)
 
         if args.border in {"expand", "expand_outpaint"}:
             padding = int(max(x.shape[1], x.shape[2]) * args.padding)
@@ -393,9 +393,9 @@ def pass4(output_path, shift_x_fix, shift_y_fix, angle_fix, transforms, scene_we
 
         if args.debug:
             z = torch.cat([x, x], dim=2)
-            return VU.to_frame(z)
+            return VU.to_frame(z, use_16bit=use_16bit)
         else:
-            return VU.to_frame(x)
+            return VU.to_frame(x, use_16bit=use_16bit)
 
     index = [0]
     buffer = [None]
@@ -489,6 +489,7 @@ def pass4(output_path, shift_x_fix, shift_y_fix, angle_fix, transforms, scene_we
         batch_size=args.batch_size,
         device=device,
         max_workers=0,
+        use_16bit=use_16bit,
     )
     VU.process_video(args.input, output_path,
                      stabilizer_callback_pool,

--- a/waifu2x/ui_utils.py
+++ b/waifu2x/ui_utils.py
@@ -275,7 +275,7 @@ def create_parser(required_true=True):
                         choices=["film", "animation", "grain", "stillimage", "psnr",
                                  "fastdecode", "zerolatency"],
                         help="encoder tunings option (video only)")
-    parser.add_argument("--pix-fmt", type=str, default="yuv420p", choices=["yuv420p", "yuv444p", "rgb24", "gbrp", "yuv420p10le"],
+    parser.add_argument("--pix-fmt", type=str, default="yuv420p", choices=["yuv420p", "yuv444p", "yuv420p10le", "rgb24", "gbrp", "gbrp10le", "gbrp16le"],
                         help=("pixel format (video only)"))
     parser.add_argument("--colorspace", type=str, default="unspecified",
                         choices=["unspecified", "auto",

--- a/waifu2x/ui_utils.py
+++ b/waifu2x/ui_utils.py
@@ -269,7 +269,8 @@ def create_parser(required_true=True):
                         help="bitrate option for libopenh264")
     parser.add_argument("--preset", type=str, default="ultrafast",
                         choices=["ultrafast", "superfast", "veryfast", "faster", "fast",
-                                 "medium", "slow", "slower", "veryslow", "placebo"],
+                                 "medium", "slow", "slower", "veryslow", "placebo",
+                                 "p1", "p2", "p3", "p4", "p5", "p6", "p7"],
                         help="encoder preset option (video only)")
     parser.add_argument("--tune", type=str, nargs="+", default=[],
                         choices=["film", "animation", "grain", "stillimage", "psnr",

--- a/waifu2x/ui_utils.py
+++ b/waifu2x/ui_utils.py
@@ -284,7 +284,9 @@ def create_parser(required_true=True):
                         help=("pixel format (video only)"))
     parser.add_argument("--colorspace", type=str, default="unspecified",
                         choices=["unspecified", "auto",
-                                 "bt709", "bt709-pc", "bt709-tv", "bt601", "bt601-pc", "bt601-tv"],
+                                 "bt709", "bt709-pc", "bt709-tv",
+                                 "bt601", "bt601-pc", "bt601-tv",
+                                 "bt2020-tv", "bt2020-pq-tv"],
                         help="video colorspace")
 
     parser.add_argument("--yes", "-y", action="store_true", default=False,

--- a/waifu2x/ui_utils.py
+++ b/waifu2x/ui_utils.py
@@ -2,7 +2,6 @@ import os
 from os import path
 import warnings
 import torch
-import torchvision.transforms.functional as TF
 from PIL import Image
 import argparse
 import csv
@@ -38,10 +37,6 @@ def make_output_filename(input_filename, args, video=False):
         return basename + args.video_extension
     else:
         return set_image_ext(basename, args.format)
-
-
-def requires_16bit(pix_fmt):
-    return pix_fmt in {"yuv420p10le"}
 
 
 @torch.inference_mode()
@@ -107,7 +102,7 @@ def process_images(ctx, files, output_dir, args, title=None):
 
 
 def process_video(ctx, input_filename, output_path, args):
-    use_16bit = requires_16bit(args.pix_fmt)
+    use_16bit = VU.pix_fmt_requires_16bit(args.pix_fmt)
     if args.compile:
         ctx.compile()
 


### PR DESCRIPTION
High bit depth video support for #372 #446 .

Basic specifications and TODO

- [x] Input: When the 0th component of the input video stream is greater than 8bit, use `rgb48le` for intermediate format. Otherwise, use `rgb24` as before.
- [x] Output: When the output `pix_fmt` is greater than 8bit(e.g., `yuv420p10le`), use `rgb48le` for intermediate format..
- [x] NVENC does not support `yuv420p10le`, so use `p010le` instead.
- [ ] Add support for `BT.2020/smpte2084`(PQ) and `BT.2020/arib-std-b67`(HLG)
- [x] Add support for yuv420p10le in iw3
- [x] Add support for yuv420p10le in waifu2x
- [x] Add support for yuv420p10le in stlizer

Implementation concern

- When using `rgb48le`, the memory transfer between CPU and GPU doubles. This could become a bottleneck and cause a slowdown in iw3.
- `p010le` in `h264_nvenc` may not be supported depending on the hardware. RTX 3070Ti does not support it. Whether it is supported can only be known by trying and seeing if an error occurs.
- PyAV does not support sidedata, so it is not possible to copy `Mastering Display Metadata`, etc.
- Support for 16bit RGB in iw3's Export feature is not planned at this time.
- MPS device (macOS) may not support torch.uint16, but it will probably be supported in the next PyTorch release.