### PR TITLE
iw3: desktop: Add support for Local Viewer

### DIFF
--- a/iw3/desktop/gui.py
+++ b/iw3/desktop/gui.py
@@ -301,10 +301,14 @@ class MainFrame(wx.Frame):
         self.cbo_stream_quality = EditableComboBox(self.grp_network, choices=["100", "95", "90", "85", "80"],
                                                    name="cbo_stream_quality")
         self.cbo_stream_quality.SetSelection(2)
+        self.chk_pad_16_9 = wx.CheckBox(self.grp_network, label=T("Padding") + " 16:9", name="chk_pad_16_9")
+        self.chk_pad_16_9.SetValue(False)
+
         self.chk_gpu_jpeg = wx.CheckBox(self.grp_network, label=T("GPU JPEG"), name="chk_gpu_jpeg")
         self.chk_gpu_jpeg.SetValue(False)
         if not ENABLE_GPU_JPEG:
             self.chk_gpu_jpeg.Disable()
+        self.sep_network1 = wx.StaticLine(self.grp_network, style=wx.LI_HORIZONTAL)
 
         self.chk_auth = wx.CheckBox(self.grp_network, label=T("Basic Authentication"), name="chk_auth")
         self.lbl_auth_username = wx.StaticText(self.grp_network, label=T("Username"))
@@ -326,12 +330,14 @@ class MainFrame(wx.Frame):
         layout.Add(self.lbl_stream_quality, (4, 0), flag=wx.ALIGN_CENTER_VERTICAL)
         layout.Add(self.cbo_stream_quality, (4, 1), flag=wx.EXPAND)
         layout.Add(self.chk_gpu_jpeg, (5, 1), flag=wx.ALIGN_CENTER_VERTICAL)
+        layout.Add(self.chk_pad_16_9, (6, 1), flag=wx.ALIGN_CENTER_VERTICAL)
+        layout.Add(self.sep_network1, (7, 0), (0, 3), flag=wx.EXPAND | wx.ALL)
 
-        layout.Add(self.chk_auth, (6, 0), (0, 3), flag=wx.ALIGN_CENTER_VERTICAL)
-        layout.Add(self.lbl_auth_username, (7, 0), flag=wx.ALIGN_CENTER_VERTICAL)
-        layout.Add(self.txt_auth_username, (7, 1), flag=wx.EXPAND)
-        layout.Add(self.lbl_auth_password, (8, 0), flag=wx.ALIGN_CENTER_VERTICAL)
-        layout.Add(self.txt_auth_password, (8, 1), flag=wx.EXPAND)
+        layout.Add(self.chk_auth, (8, 0), (0, 3), flag=wx.ALIGN_CENTER_VERTICAL)
+        layout.Add(self.lbl_auth_username, (9, 0), flag=wx.ALIGN_CENTER_VERTICAL)
+        layout.Add(self.txt_auth_username, (9, 1), flag=wx.EXPAND)
+        layout.Add(self.lbl_auth_password, (10, 0), flag=wx.ALIGN_CENTER_VERTICAL)
+        layout.Add(self.txt_auth_password, (10, 1), flag=wx.EXPAND)
 
         sizer_network = wx.StaticBoxSizer(self.grp_network, wx.VERTICAL)
         sizer_network.Add(layout, 1, wx.ALL | wx.EXPAND, 4)
@@ -551,7 +557,6 @@ class MainFrame(wx.Frame):
         self.sld_adj_convergence.Bind(wx.EVT_SPINCTRLDOUBLE, self.update_args_adjustment)
         self.sld_adj_edge_dilation.Bind(wx.EVT_SPINCTRL, self.update_args_adjustment)
         self.sld_adj_foreground_scale.Bind(wx.EVT_SPINCTRLDOUBLE, self.update_args_adjustment)
-
         self.btn_detect_ip.Bind(wx.EVT_BUTTON, self.on_click_btn_detect_ip)
         self.btn_url.Bind(wx.EVT_BUTTON, self.on_click_btn_url)
         self.btn_start.Bind(wx.EVT_BUTTON, self.on_click_btn_start)
@@ -844,6 +849,7 @@ class MainFrame(wx.Frame):
         if not window_name:
             window_name = None
 
+        pad_mode = "16:9" if self.chk_pad_16_9.IsChecked() else None
         parser.set_defaults(
             gpu=device_id,
             divergence=float(self.cbo_divergence.GetValue()),
@@ -877,6 +883,7 @@ class MainFrame(wx.Frame):
             full_sbs=full_sbs,
             rgbd=rgbd,
             half_rgbd=half_rgbd,
+            pad_mode=pad_mode,
         )
         args = parser.parse_args()
         set_state_args(

--- a/iw3/desktop/gui.py
+++ b/iw3/desktop/gui.py
@@ -1150,36 +1150,28 @@ class MainFrame(wx.Frame):
 
     def update_view_mode(self, *args, **kwargs):
         local_viewer = self.cbo_view_mode.GetValue() == "Local Viewer"
+        streaming_options = [
+            self.chk_bind_addr,
+            self.txt_bind_addr,
+            self.btn_detect_ip,
+            self.lbl_port,
+            self.txt_port,
+            self.lbl_stream_quality,
+            self.cbo_stream_quality,
+            self.chk_gpu_jpeg,
+            self.sep_network1,
+            self.chk_auth,
+            self.lbl_auth_username,
+            self.txt_auth_username,
+            self.lbl_auth_password,
+            self.txt_auth_password,
+        ]
         if local_viewer:
-            self.chk_bind_addr.Hide()
-            self.txt_bind_addr.Hide()
-            self.btn_detect_ip.Hide()
-            self.lbl_port.Hide()
-            self.txt_port.Hide()
-            self.lbl_stream_quality.Hide()
-            self.cbo_stream_quality.Hide()
-            self.chk_gpu_jpeg.Hide()
-            self.sep_network1.Hide()
-            self.chk_auth.Hide()
-            self.lbl_auth_username.Hide()
-            self.txt_auth_username.Hide()
-            self.lbl_auth_password.Hide()
-            self.txt_auth_password.Hide()
+            for control in streaming_options:
+                control.Hide()
         else:
-            self.chk_bind_addr.Show()
-            self.txt_bind_addr.Show()
-            self.btn_detect_ip.Show()
-            self.lbl_port.Show()
-            self.txt_port.Show()
-            self.lbl_stream_quality.Show()
-            self.cbo_stream_quality.Show()
-            self.chk_gpu_jpeg.Show()
-            self.sep_network1.Show()
-            self.chk_auth.Show()
-            self.lbl_auth_username.Show()
-            self.txt_auth_username.Show()
-            self.lbl_auth_password.Show()
-            self.txt_auth_password.Show()
+            for control in streaming_options:
+                control.Show()
 
         self.GetSizer().Layout()
         self.Fit()

--- a/iw3/desktop/gui.py
+++ b/iw3/desktop/gui.py
@@ -275,6 +275,12 @@ class MainFrame(wx.Frame):
         if LAYOUT_DEBUG:
             self.grp_network.SetBackgroundColour("#fcf")
 
+        self.lbl_view_mode = wx.StaticText(self.grp_network, label=T("View Mode"))
+        self.cbo_view_mode = wx.ComboBox(self.grp_network, choices=["Web Streaming", "Local Viewer"],
+                                         name="cbo_view_mode")
+        self.cbo_view_mode.SetEditable(False)
+        self.cbo_view_mode.SetSelection(0)
+
         self.chk_bind_addr = wx.CheckBox(self.grp_network, label=T("Address"), name="chk_bind_addr")
         self.txt_bind_addr = IpAddrCtrl(self.grp_network, size=self.FromDIP((200, -1)), name="txt_bind_addr")
 
@@ -318,26 +324,29 @@ class MainFrame(wx.Frame):
 
         layout = wx.GridBagSizer(vgap=5, hgap=4)
         layout.SetEmptyCellSize((0, 0))
-        layout.Add(self.chk_bind_addr, (0, 0), flag=wx.ALIGN_CENTER_VERTICAL)
-        layout.Add(self.txt_bind_addr, (0, 1), flag=wx.EXPAND)
-        layout.Add(self.btn_detect_ip, (0, 2), flag=wx.ALIGN_CENTER_VERTICAL)
-        layout.Add(self.lbl_port, (1, 0), flag=wx.ALIGN_CENTER_VERTICAL)
-        layout.Add(self.txt_port, (1, 1), flag=wx.EXPAND)
-        layout.Add(self.lbl_stream_fps, (2, 0), flag=wx.ALIGN_CENTER_VERTICAL)
-        layout.Add(self.cbo_stream_fps, (2, 1), flag=wx.EXPAND)
-        layout.Add(self.lbl_stream_height, (3, 0), flag=wx.ALIGN_CENTER_VERTICAL)
-        layout.Add(self.cbo_stream_height, (3, 1), flag=wx.EXPAND)
-        layout.Add(self.lbl_stream_quality, (4, 0), flag=wx.ALIGN_CENTER_VERTICAL)
-        layout.Add(self.cbo_stream_quality, (4, 1), flag=wx.EXPAND)
-        layout.Add(self.chk_gpu_jpeg, (5, 1), flag=wx.ALIGN_CENTER_VERTICAL)
-        layout.Add(self.chk_pad_16_9, (6, 1), flag=wx.ALIGN_CENTER_VERTICAL)
-        layout.Add(self.sep_network1, (7, 0), (0, 3), flag=wx.EXPAND | wx.ALL)
+        layout.Add(self.lbl_view_mode, (0, 0), flag=wx.ALIGN_CENTER_VERTICAL)
+        layout.Add(self.cbo_view_mode, (0, 1), flag=wx.EXPAND)
 
-        layout.Add(self.chk_auth, (8, 0), (0, 3), flag=wx.ALIGN_CENTER_VERTICAL)
-        layout.Add(self.lbl_auth_username, (9, 0), flag=wx.ALIGN_CENTER_VERTICAL)
-        layout.Add(self.txt_auth_username, (9, 1), flag=wx.EXPAND)
-        layout.Add(self.lbl_auth_password, (10, 0), flag=wx.ALIGN_CENTER_VERTICAL)
-        layout.Add(self.txt_auth_password, (10, 1), flag=wx.EXPAND)
+        layout.Add(self.chk_bind_addr, (1, 0), flag=wx.ALIGN_CENTER_VERTICAL)
+        layout.Add(self.txt_bind_addr, (1, 1), flag=wx.EXPAND)
+        layout.Add(self.btn_detect_ip, (1, 2), flag=wx.ALIGN_CENTER_VERTICAL)
+        layout.Add(self.lbl_port, (2, 0), flag=wx.ALIGN_CENTER_VERTICAL)
+        layout.Add(self.txt_port, (2, 1), flag=wx.EXPAND)
+        layout.Add(self.lbl_stream_fps, (3, 0), flag=wx.ALIGN_CENTER_VERTICAL)
+        layout.Add(self.cbo_stream_fps, (3, 1), flag=wx.EXPAND)
+        layout.Add(self.lbl_stream_height, (4, 0), flag=wx.ALIGN_CENTER_VERTICAL)
+        layout.Add(self.cbo_stream_height, (4, 1), flag=wx.EXPAND)
+        layout.Add(self.lbl_stream_quality, (5, 0), flag=wx.ALIGN_CENTER_VERTICAL)
+        layout.Add(self.cbo_stream_quality, (5, 1), flag=wx.EXPAND)
+        layout.Add(self.chk_gpu_jpeg, (6, 1), flag=wx.ALIGN_CENTER_VERTICAL)
+        layout.Add(self.chk_pad_16_9, (7, 1), flag=wx.ALIGN_CENTER_VERTICAL)
+        layout.Add(self.sep_network1, (8, 0), (0, 3), flag=wx.EXPAND | wx.ALL)
+
+        layout.Add(self.chk_auth, (9, 0), (0, 3), flag=wx.ALIGN_CENTER_VERTICAL)
+        layout.Add(self.lbl_auth_username, (10, 0), flag=wx.ALIGN_CENTER_VERTICAL)
+        layout.Add(self.txt_auth_username, (10, 1), flag=wx.EXPAND)
+        layout.Add(self.lbl_auth_password, (11, 0), flag=wx.ALIGN_CENTER_VERTICAL)
+        layout.Add(self.txt_auth_password, (11, 1), flag=wx.EXPAND)
 
         sizer_network = wx.StaticBoxSizer(self.grp_network, wx.VERTICAL)
         sizer_network.Add(layout, 1, wx.ALL | wx.EXPAND, 4)
@@ -557,6 +566,9 @@ class MainFrame(wx.Frame):
         self.sld_adj_convergence.Bind(wx.EVT_SPINCTRLDOUBLE, self.update_args_adjustment)
         self.sld_adj_edge_dilation.Bind(wx.EVT_SPINCTRL, self.update_args_adjustment)
         self.sld_adj_foreground_scale.Bind(wx.EVT_SPINCTRLDOUBLE, self.update_args_adjustment)
+
+        self.cbo_view_mode.Bind(wx.EVT_TEXT, self.on_text_changed_cbo_view_mode)
+
         self.btn_detect_ip.Bind(wx.EVT_BUTTON, self.on_click_btn_detect_ip)
         self.btn_url.Bind(wx.EVT_BUTTON, self.on_click_btn_url)
         self.btn_start.Bind(wx.EVT_BUTTON, self.on_click_btn_start)
@@ -581,6 +593,7 @@ class MainFrame(wx.Frame):
         self.update_ema_normalize()
         self.update_divergence_warning()
         self.update_preserve_screen_border()
+        self.update_view_mode()
         self.update_monitor_index()
         self.update_window_names()
         self.update_compile()
@@ -850,6 +863,25 @@ class MainFrame(wx.Frame):
             window_name = None
 
         pad_mode = "16:9" if self.chk_pad_16_9.IsChecked() else None
+        local_viewer = self.cbo_view_mode.GetValue() == "Local Viewer"
+        if local_viewer:
+            viewer_kwargs = dict(
+                local_viewer=True,
+                stream_fps=int(self.cbo_stream_fps.GetValue()),
+                stream_height=int(self.cbo_stream_height.GetValue()),
+            )
+        else:
+            viewer_kwargs = dict(
+                bind_addr=bind_addr,
+                port=self.txt_port.GetValue(),
+                user=user,
+                password=password,
+                stream_fps=int(self.cbo_stream_fps.GetValue()),
+                stream_height=int(self.cbo_stream_height.GetValue()),
+                stream_quality=int(self.cbo_stream_quality.GetValue()),
+                gpu_jpeg=self.chk_gpu_jpeg.IsEnabled() and self.chk_gpu_jpeg.IsChecked(),
+            )
+
         parser.set_defaults(
             gpu=device_id,
             divergence=float(self.cbo_divergence.GetValue()),
@@ -865,14 +897,6 @@ class MainFrame(wx.Frame):
             resolution=resolution,
             compile=self.chk_compile.IsEnabled() and self.chk_compile.IsChecked(),
 
-            bind_addr=bind_addr,
-            port=self.txt_port.GetValue(),
-            user=user,
-            password=password,
-            stream_fps=int(self.cbo_stream_fps.GetValue()),
-            stream_height=int(self.cbo_stream_height.GetValue()),
-            stream_quality=int(self.cbo_stream_quality.GetValue()),
-            gpu_jpeg=self.chk_gpu_jpeg.IsEnabled() and self.chk_gpu_jpeg.IsChecked(),
             screenshot=self.cbo_screenshot.GetValue(),
             monitor_index=monitor_index,
             window_name=window_name,
@@ -884,6 +908,8 @@ class MainFrame(wx.Frame):
             rgbd=rgbd,
             half_rgbd=half_rgbd,
             pad_mode=pad_mode,
+
+            **viewer_kwargs,
         )
         args = parser.parse_args()
         set_state_args(
@@ -1118,6 +1144,45 @@ class MainFrame(wx.Frame):
             self.lbl_crop_bottom.Hide()
 
         self.GetSizer().Layout()
+
+    def on_text_changed_cbo_view_mode(self, event):
+        self.update_view_mode()
+
+    def update_view_mode(self, *args, **kwargs):
+        local_viewer = self.cbo_view_mode.GetValue() == "Local Viewer"
+        if local_viewer:
+            self.chk_bind_addr.Hide()
+            self.txt_bind_addr.Hide()
+            self.btn_detect_ip.Hide()
+            self.lbl_port.Hide()
+            self.txt_port.Hide()
+            self.lbl_stream_quality.Hide()
+            self.cbo_stream_quality.Hide()
+            self.chk_gpu_jpeg.Hide()
+            self.sep_network1.Hide()
+            self.chk_auth.Hide()
+            self.lbl_auth_username.Hide()
+            self.txt_auth_username.Hide()
+            self.lbl_auth_password.Hide()
+            self.txt_auth_password.Hide()
+        else:
+            self.chk_bind_addr.Show()
+            self.txt_bind_addr.Show()
+            self.btn_detect_ip.Show()
+            self.lbl_port.Show()
+            self.txt_port.Show()
+            self.lbl_stream_quality.Show()
+            self.cbo_stream_quality.Show()
+            self.chk_gpu_jpeg.Show()
+            self.sep_network1.Show()
+            self.chk_auth.Show()
+            self.lbl_auth_username.Show()
+            self.txt_auth_username.Show()
+            self.lbl_auth_password.Show()
+            self.txt_auth_password.Show()
+
+        self.GetSizer().Layout()
+        self.Fit()
 
 
 LOCAL_LIST = sorted(list(LOCALES.keys()))

--- a/iw3/desktop/local_viewer.py
+++ b/iw3/desktop/local_viewer.py
@@ -1,0 +1,276 @@
+import wx
+from wx import glcanvas
+from OpenGL import GL
+import torch
+import threading
+import time
+from collections import deque
+
+
+class GLCanvas(glcanvas.GLCanvas):
+    def __init__(self, parent, width, height):
+        attribs = [
+            glcanvas.WX_GL_RGBA,
+            glcanvas.WX_GL_DOUBLEBUFFER,
+        ]
+        super().__init__(parent, attribList=attribs, size=(width, height))
+        self.context = glcanvas.GLContext(self)
+        self.initialized = False
+        self.closed = False
+        self.fps_counter = deque(maxlen=120)
+
+        self.tex_id = None
+        self.tex_w = width
+        self.tex_h = height
+        self.frame = None
+
+        self.Bind(wx.EVT_PAINT, self.on_paint)
+        self.Bind(wx.EVT_SIZE, self.on_resize)
+        self.Bind(wx.EVT_ERASE_BACKGROUND, lambda e: None)
+
+    def init_gl(self, evt=None):
+        self.SetCurrent(self.context)
+        GL.glDisable(GL.GL_DEPTH_TEST)
+        GL.glClearColor(0, 0, 0, 1)
+        GL.glViewport(0, 0, *self.GetClientSize())
+
+        self.tex_id = GL.glGenTextures(1)
+        GL.glBindTexture(GL.GL_TEXTURE_2D, self.tex_id)
+        GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MIN_FILTER, GL.GL_LINEAR)
+        GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MAG_FILTER, GL.GL_LINEAR)
+        GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_WRAP_S, GL.GL_CLAMP_TO_EDGE)
+        GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_WRAP_T, GL.GL_CLAMP_TO_EDGE)
+        GL.glTexImage2D(GL.GL_TEXTURE_2D, 0, GL.GL_RGB, self.tex_w, self.tex_h, 0,
+                        GL.GL_RGB, GL.GL_UNSIGNED_BYTE, None)
+        GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
+        self.initialized = True
+
+    def update_frame(self, frame):
+        if self.closed:
+            return
+        if not self.initialized:
+            # skip
+            self.Refresh()
+            return
+
+        assert (
+            frame.ndim == 3 and
+            frame.shape[0] == 3 and
+            frame.shape[1] == self.tex_h and
+            frame.shape[2] == self.tex_w and
+            frame.dtype == torch.float32
+        )
+        self.frame = frame
+        self.Refresh()
+
+    def set_tex(self):
+        if self.frame is None:
+            return
+
+        frame = self.frame
+        c, h, w = frame.shape
+        self.tex_w = w
+        self.tex_h = h
+
+        frame = frame.permute(1, 2, 0).contiguous()
+        frame = (frame.clamp(0, 1) * 255).to(torch.uint8).cpu().numpy()
+
+        GL.glBindTexture(GL.GL_TEXTURE_2D, self.tex_id)
+        GL.glTexSubImage2D(GL.GL_TEXTURE_2D, 0, 0, 0, w, h, GL.GL_RGB, GL.GL_UNSIGNED_BYTE, frame)
+        GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
+
+        self.frame = None
+        self.fps_counter.append(time.perf_counter())
+
+    def draw(self):
+        W, H = self.GetClientSize()
+        GL.glViewport(0, 0, W, H)
+        GL.glClear(GL.GL_COLOR_BUFFER_BIT)
+
+        GL.glMatrixMode(GL.GL_PROJECTION)
+        GL.glLoadIdentity()
+        # GL.glOrtho(0, W, 0, H, -1, 1)
+        GL.glOrtho(0, W, H, 0, -1, 1)
+        GL.glMatrixMode(GL.GL_MODELVIEW)
+        GL.glLoadIdentity()
+
+        GL.glEnable(GL.GL_TEXTURE_2D)
+        GL.glBindTexture(GL.GL_TEXTURE_2D, self.tex_id)
+
+        scale = min(W / self.tex_w, H / self.tex_h)
+        draw_w = self.tex_w * scale
+        draw_h = self.tex_h * scale
+        x0 = (W - draw_w) / 2
+        y0 = (H - draw_h) / 2
+        x1 = x0 + draw_w
+        y1 = y0 + draw_h
+
+        GL.glBegin(GL.GL_QUADS)
+
+        GL.glTexCoord2f(0, 0)
+        GL.glVertex2f(x0, y0)
+
+        GL.glTexCoord2f(1, 0)
+        GL.glVertex2f(x1, y0)
+
+        GL.glTexCoord2f(1, 1)
+        GL.glVertex2f(x1, y1)
+
+        GL.glTexCoord2f(0, 1)
+        GL.glVertex2f(x0, y1)
+
+        GL.glEnd()
+
+        GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
+        GL.glDisable(GL.GL_TEXTURE_2D)
+
+    def on_paint(self, evt):
+        if self.closed:
+            return
+        if not self.initialized:
+            self.init_gl()
+
+        self.SetCurrent(self.context)
+        self.set_tex()
+        self.draw()
+        self.SwapBuffers()
+
+    def on_resize(self, evt):
+        if self.closed:
+            return
+        if self.initialized:
+            self.SetCurrent(self.context)
+            w, h = self.GetClientSize()
+            GL.glViewport(0, 0, max(1, w), max(1, h))
+        evt.Skip()
+        self.Refresh()
+
+    def get_fps(self):
+        if self.closed:
+            return 0.0
+
+        diff = []
+        prev = None
+        for t in self.fps_counter:
+            if prev is not None:
+                diff.append(t - prev)
+            prev = t
+        if diff:
+            fps = 1.0 / (sum(diff) / len(diff))
+        else:
+            fps = 0.0
+        return fps
+
+
+class LocalViewerWindow(wx.Frame):
+    def __init__(self, width, height, size=(960, 540)):
+        super().__init__(None, title="Local Viewer", size=size, style=wx.DEFAULT_FRAME_STYLE | wx.CLIP_CHILDREN)
+        self.canvas = GLCanvas(self, width=width, height=height)
+        self.callafter_pending = False
+
+        self.Bind(wx.EVT_CLOSE, self.on_close)
+        self.Bind(wx.EVT_CHAR_HOOK, self.on_char)
+
+    def toggle_fullscreen(self):
+        is_full = self.IsFullScreen()
+        self.ShowFullScreen(not is_full, style=wx.FULLSCREEN_ALL)
+
+    def escape_fullscreen(self):
+        self.ShowFullScreen(False, style=wx.FULLSCREEN_ALL)
+
+    def on_char(self, evt):
+        code = evt.GetKeyCode()
+        if code == wx.WXK_ESCAPE and self.IsFullScreen():
+            self.toggle_fullscreen()
+        elif code == wx.WXK_F11:
+            self.toggle_fullscreen()
+        else:
+            evt.Skip()
+
+    def update_frame(self, frame):
+        if not self.canvas.closed:
+            self.canvas.update_frame(frame)
+
+    def get_fps(self):
+        return self.canvas.get_fps()
+
+    def on_close(self, evt):
+        self.canvas.closed = True
+        if self.canvas.initialized:
+            self.canvas.initialized = False
+            self.canvas.SetCurrent(self.canvas.context)
+            if self.canvas.tex_id:
+                GL.glDeleteTextures([self.canvas.tex_id])
+                self.canvas.tex_id = None
+        evt.Skip()
+
+
+class LocalViewer():
+    def __init__(self, lock, width, height, **_unsupported_kwargs):
+        self.width = width
+        self.height = height
+        self.lock = lock
+        self.op_lock = threading.Lock()
+        self.window = None
+        self.last_frame_time = 0
+
+    def stop(self):
+        with self.op_lock:
+            if self.window is not None:
+                window = self.window
+                self.window = None
+                wx.CallAfter(window.Close)
+
+    def _start(self):
+        with self.op_lock:
+            if self.window is None:
+                self.window = LocalViewerWindow(width=self.width, height=self.height)
+                self.window.Show()
+
+    def start(self):
+        if not (wx.GetApp() and wx.GetApp().IsMainLoopRunning()):
+            raise RuntimeError("Not in wx.MainLoop")
+        wx.CallAfter(self._start)
+
+    def set_frame_data(self, frame_data):
+        frame, frame_time = frame_data
+        if self.window is not None and self.last_frame_time < frame_time:
+            wx.CallAfter(self.window.update_frame, frame)
+
+    def get_fps(self):
+        if self.window is not None:
+            return self.window.get_fps()
+        else:
+            return 0.0
+
+
+def _test():
+    W = 3840
+    H = 2160
+    FPS = 60
+
+    def main():
+        lock = threading.RLock()
+        server = LocalViewer(lock, width=W, height=H)
+        server.start()
+        frames = torch.rand(8, 3, H, W).cuda()
+        for i in range(300):
+            frame = frames[i % frames.shape[0]]
+            server.set_frame_data((frame, time.time()))
+            time.sleep(1 / FPS)
+        print(f"{W}x{H}, {round(server.get_fps(), 2)}FPS")
+        print("CTRL+C to exit")
+
+        server.stop()
+
+    def start():
+        threading.Thread(target=main).start()
+
+    app = wx.App()
+    frame = wx.Frame(None)  # noqa
+    wx.CallAfter(start)
+    app.MainLoop()
+
+
+if __name__ == '__main__':
+    _test()

--- a/iw3/desktop/local_viewer.py
+++ b/iw3/desktop/local_viewer.py
@@ -76,6 +76,7 @@ class GLCanvas(glcanvas.GLCanvas):
         frame = (frame.clamp(0, 1) * 255).to(torch.uint8).cpu().numpy()
 
         GL.glBindTexture(GL.GL_TEXTURE_2D, self.tex_id)
+        GL.glPixelStorei(GL.GL_UNPACK_ALIGNMENT, 1)
         GL.glTexSubImage2D(GL.GL_TEXTURE_2D, 0, 0, 0, w, h, GL.GL_RGB, GL.GL_UNSIGNED_BYTE, frame)
         GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
 

--- a/iw3/locales/ja.yml
+++ b/iw3/locales/ja.yml
@@ -107,6 +107,7 @@
 
 # iw3.desktop
 "Network": "ネットワーク"
+"View Mode": "表示モード"
 "Address": "アドレス"
 "Port": "ポート"
 "Streaming FPS": "ストリーミング FPS"

--- a/iw3/locales/zh_CN.yml
+++ b/iw3/locales/zh_CN.yml
@@ -112,6 +112,7 @@
 
 # iw3.desktop
 "Network": "网络"
+"View Mode": "显示模式"
 "Address": "地址"
 "Port": "端口"
 "Streaming FPS": "流媒体帧率"

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,3 +1,7 @@
 wxpython >= 4.0.0
 pywin32; sys_platform == 'win32'
 windows_capture==1.4.2; sys_platform == 'win32'
+PyOpenGL==3.1.9
+# PyOpenGL_accelerate is not required, but it is recommended.
+# If installation fails, you can ignore it.
+PyOpenGL_accelerate==3.1.9


### PR DESCRIPTION
This PR adds the local GUI viewer for iw3.desktop requested in #458 #426 #402.
Note: I have not used any device or software that captures GUI windows, so I do not know if it actually works.

- Add `Network > View Mode` option in GUI (`Web Streaming` or `Local Viewer`)
- Add `--local-viewer` option in CLI
- Add `Padding 16:9` option in GUI

`Padding 16:9` option is probably necessary when capturing a vertical application window in Local Viewer mode. It places the left and right views in the center of a 16:9 frame. This assumes that the output monitor is 16:9.

Regarding Local Viewer performance, on my Linux system it can render 4K at 60FPS, so it is probably not a problem. On Windows, I have only confirmed that it works.

The Local Viewer can switch full screen with `F11` and exit full screen with `ESC`.