### PR TITLE
iw3: desktop: Local viewer fixes

### DIFF
--- a/iw3/desktop/gui.py
+++ b/iw3/desktop/gui.py
@@ -649,15 +649,19 @@ class MainFrame(wx.Frame):
         return editable_comboboxes
 
     def on_close(self, event):
+        self.save_preset()
+        event.Skip()
+
+        self.stop_event.set()
         if self.processing:
-            self.stop_event.set()
-            max_wait = int(4 / 0.01)
+            max_wait = int(6 / 0.01)
             for _ in range(max_wait):
                 if not self.stop_event.is_set():
                     break
                 time.sleep(0.01)
-        self.save_preset()
-        event.Skip()
+            if self.stop_event.is_set():
+                # It may be deadlocked, so force exit
+                os._exit(-1)
 
     def update_depth_model_list(self, *args, **kwargs):
         default_model = "Any_V2_S"

--- a/iw3/desktop/local_viewer.py
+++ b/iw3/desktop/local_viewer.py
@@ -42,7 +42,7 @@ class GLCanvas(glcanvas.GLCanvas):
         GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MAG_FILTER, GL.GL_LINEAR)
         GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_WRAP_S, GL.GL_CLAMP_TO_EDGE)
         GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_WRAP_T, GL.GL_CLAMP_TO_EDGE)
-        GL.glTexImage2D(GL.GL_TEXTURE_2D, 0, GL.GL_RGB, self.tex_w, self.tex_h, 0,
+        GL.glTexImage2D(GL.GL_TEXTURE_2D, 0, GL.GL_RGB8, self.tex_w, self.tex_h, 0,
                         GL.GL_RGB, GL.GL_UNSIGNED_BYTE, None)
         GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
 

--- a/iw3/desktop/local_viewer.py
+++ b/iw3/desktop/local_viewer.py
@@ -52,6 +52,24 @@ class GLCanvas(glcanvas.GLCanvas):
 
         self.initialized = True
 
+    def delete_gl(self):
+        if not self.initialized:
+            return
+        self.initialized = False
+        self.SetCurrent(self.context)
+        if self.tex_id:
+            GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
+            GL.glDeleteTextures([self.tex_id])
+            self.tex_id = None
+        if self.pbo:
+            GL.glBindBuffer(GL.GL_PIXEL_UNPACK_BUFFER, 0)
+            GL.glDeleteBuffers(1, [self.pbo])
+            self.pbo = None
+
+    def destroy(self):
+        self.closed = True
+        self.delete_gl()
+
     def update_frame(self, frame):
         if self.closed:
             return
@@ -208,13 +226,7 @@ class LocalViewerWindow(wx.Frame):
         return self.canvas.get_fps()
 
     def on_close(self, evt):
-        self.canvas.closed = True
-        if self.canvas.initialized:
-            self.canvas.initialized = False
-            self.canvas.SetCurrent(self.canvas.context)
-            if self.canvas.tex_id:
-                GL.glDeleteTextures([self.canvas.tex_id])
-                self.canvas.tex_id = None
+        self.canvas.destroy()
         evt.Skip()
 
     def is_closed(self):

--- a/iw3/desktop/screenshot_thread_pil.py
+++ b/iw3/desktop/screenshot_thread_pil.py
@@ -31,7 +31,7 @@ def to_tensor(pil_image, device, frame_buffer):
 
 class ScreenshotThreadPIL(threading.Thread):
     def __init__(self, fps, frame_width, frame_height, monitor_index, window_name, device, **_ignore_unsupported_kwargs):
-        super().__init__()
+        super().__init__(daemon=True)
         self.frame_width = frame_width
         self.frame_height = frame_height
         self.monitor_index = monitor_index  # TODO: not implemented
@@ -110,4 +110,4 @@ class ScreenshotThreadPIL(threading.Thread):
         self.stop_event.set()
         self.frame_unset_event.set()
         if self.ident is not None:
-            self.join()
+            self.join(timeout=4)

--- a/iw3/desktop/streaming_server.py
+++ b/iw3/desktop/streaming_server.py
@@ -17,6 +17,7 @@ STATUS_OK = "200 OK"
 
 
 class ThreadingWSGIServer(ThreadingMixIn, WSGIServer):
+    daemon_threads = True
     allow_reuse_address = True
     block_on_close = False
 


### PR DESCRIPTION
- Ensure that frame data is not released by GC before use. (Copy to PBO)
- Explicitly release OpenGL resources.
- Fix window.Close getting called twice (Fix `RuntimeError: wrapped C/C++ object of type LocalViewerWindow has been deleted` error)
- Attempt to fix process not terminating after window close. Force other threads  to terminate when the main thread ends (Use `Thread(daemon=true)`)
