### PR TITLE
iw3: desktop: --bind-addr fixes

### DIFF
--- a/iw3/desktop/gui.py
+++ b/iw3/desktop/gui.py
@@ -34,6 +34,8 @@ from ..video_depth_anything_streaming_model import VideoDepthAnythingStreamingMo
 from ..locales import LOCALES, load_language_setting, save_language_setting
 from .utils import (
     get_local_address,
+    is_private_address,
+    is_loopback_address,
     init_win32,
     iw3_desktop_main,
     create_parser, set_state_args,
@@ -735,8 +737,11 @@ class MainFrame(wx.Frame):
 
     def update_bind_addr_warning(self, *args, **kwargs):
         bind_addr = self.txt_bind_addr.GetAddress()
-        if bind_addr == "127.0.0.1":
-            self.lbl_bind_addr_warning.SetLabel("127.0.0.1 is only accessible from this PC.")
+        if is_loopback_address(bind_addr):
+            self.lbl_bind_addr_warning.SetLabel(f"{bind_addr} is only accessible from this PC.")
+            self.lbl_bind_addr_warning.Show()
+        elif not is_private_address(bind_addr):
+            self.lbl_bind_addr_warning.SetLabel(f"{bind_addr} is not Local Area Network Address.")
             self.lbl_bind_addr_warning.Show()
         else:
             self.lbl_bind_addr_warning.SetLabel("")

--- a/iw3/desktop/utils.py
+++ b/iw3/desktop/utils.py
@@ -184,9 +184,15 @@ def iw3_desktop_main(args, init_wxapp=True):
         args.bind_addr = get_local_address()
     if args.bind_addr == "0.0.0.0":
         pass  # Allows specifying undefined addresses
-    elif args.bind_addr == "127.0.0.1" or not is_private_address(args.bind_addr):
+    elif not is_private_address(args.bind_addr):
         raise RuntimeError(f"Detected IP address({args.bind_addr}) is not Local Area Network Address."
                            " Specify --bind-addr option")
+    if args.bind_addr == "127.0.0.1":
+        print(
+            ("Warning: 127.0.0.1 is only accessible from this PC. "
+             "If this option is not explicitly enabled, the network connection might be unavailable."),
+            file=sys.stderr
+        )
 
     if args.screenshot == "pil":
         screenshot_factory = ScreenshotThreadPIL

--- a/iw3/desktop/utils.py
+++ b/iw3/desktop/utils.py
@@ -180,19 +180,20 @@ def iw3_desktop_main(args, init_wxapp=True):
     if not (args.full_sbs or args.rgbd or args.half_rgbd):
         args.half_sbs = True
 
-    if args.bind_addr is None:
-        args.bind_addr = get_local_address()
-    if args.bind_addr == "0.0.0.0":
-        pass  # Allows specifying undefined addresses
-    elif not is_private_address(args.bind_addr):
-        raise RuntimeError(f"Detected IP address({args.bind_addr}) is not Local Area Network Address."
-                           " Specify --bind-addr option")
-    if args.bind_addr == "127.0.0.1":
-        print(
-            ("Warning: 127.0.0.1 is only accessible from this PC. "
-             "If this option is not explicitly enabled, the network connection might be unavailable."),
-            file=sys.stderr
-        )
+    if not args.local_viewer:
+        if args.bind_addr is None:
+            args.bind_addr = get_local_address()
+        if args.bind_addr == "0.0.0.0":
+            pass  # Allows specifying undefined addresses
+        elif not is_private_address(args.bind_addr):
+            raise RuntimeError(f"Detected IP address({args.bind_addr}) is not Local Area Network Address."
+                               " Specify --bind-addr option")
+        if args.bind_addr == "127.0.0.1":
+            print(
+                ("Warning: 127.0.0.1 is only accessible from this PC. "
+                 "If this option is not explicitly enabled, the network connection might be unavailable."),
+                file=sys.stderr
+            )
 
     if args.screenshot == "pil":
         screenshot_factory = ScreenshotThreadPIL


### PR DESCRIPTION
Changes for #461

- Allow binding to 127.0.0.1 but show a warning "127.0.0.1 is only accessible from this PC.".
- Skip IP address validation when Local Viewer mode.
- Allow non-private IP address when Basic authentication is enabled.
