### PR TITLE
windows_package: Clear GITHUB_TOKEN

### DIFF
--- a/windows_package/setenv.bat
+++ b/windows_package/setenv.bat
@@ -31,3 +31,6 @@ if exist "%VCVARS2022_PATH%" (
 @rem set vslang to English to avoid UnicodeDecodeError
 @rem note that this will not work unless the English language package is installed
 set VSLANG=1033
+
+@rem clear github token
+set GITHUB_TOKEN=


### PR DESCRIPTION
The code in this repository does not access URLs that require authentication, but `HTTP Error 401: Unauthorized` errors may occur if `torch.hub` uses an expired `GITHUB_TOKEN` environment variable.
Fix https://github.com/nagadomi/nunif/issues/464

In Windows bat files, it seems that environment variables can be unset with `set GITHUB_TOKEN=`.
(`os.environ.get("GITHUB_TOKEN")` returns `None` rather than an empty string.)

