### PR TITLE
iw3: Add VDA_B, VDA_Metric_S, VDA_Metric_B, VDA_Stream_B

### DIFF
--- a/iw3/README.md
+++ b/iw3/README.md
@@ -413,8 +413,15 @@ Perhaps what is needed is fine tuning for ZoeDepth.
 | `Distill_Any_B`  | Distill Any Depth model base.
 | `Distill_Any_L`  | Distill Any Depth model large.
 | `VDA_S`  | Video Depth Anything small.
-| `VDA_L`  | Video Depth Anything large.
-| `VDA_Metric`  | Video Depth Anything metric depth model.
+| `VDA_B`  | Video Depth Anything base. (cc-by-nc-4.0)
+| `VDA_L`  | Video Depth Anything large. (cc-by-nc-4.0)
+| `VDA_Metric_S`  | Video Depth Anything metric depth small model.
+| `VDA_Metric_B`  | Video Depth Anything metric depth base model. (cc-by-nc-4.0)
+| `VDA_Metric_L`  | Video Depth Anything metric depth large model. (cc-by-nc-4.0)
+| `VDA_Stream_S`  | Video Depth Anything streaming model small.
+| `VDA_Stream_B`  | Video Depth Anything streaming model base. (cc-by-nc-4.0)
+| `VDA_Stream_L`  | Video Depth Anything streaming model large. (cc-by-nc-4.0)
+
 
 Personally, I recommend `ZoeD_Any_N`, `Any_B` or `VDA_Metric`.
 `ZoeD_Any_N` looks the best for 3D scene. The DepthAnything models have more accurate foreground and background segmentation, but the foreground looks slightly flat.
@@ -446,7 +453,7 @@ These files can be downloaded from Models section of https://huggingface.co/dept
 
 ### About Video-Depth-Anything
 
-#### `VDA_L`, `VDA_Metric`
+#### `VDA_B`, `VDA_L`, `VDA_Metric_B`, `VDA_Metric_L`
 
 These models are licensed under cc-by-nc-4.0 (Non Commercial).
 If you want to use it, agree to the pre-trained model license and place the checkpoint file yourself.
@@ -454,12 +461,18 @@ If you want to use it, agree to the pre-trained model license and place the chec
 | Short Name | Path |
 |------------|------|
 | `VDA_L` | `iw3/pretrained_models/hub/checkpoints/video_depth_anything_vitl.pth`
-| `VDA_Metric` | `iw3/pretrained_models/hub/checkpoints/metric_video_depth_anything_vitl.pth`
+| `VDA_B` | `iw3/pretrained_models/hub/checkpoints/video_depth_anything_vitb.pth`
+| `VDA_Metric_B` | `iw3/pretrained_models/hub/checkpoints/metric_video_depth_anything_vitb.pth`
+| `VDA_Metric_L` | `iw3/pretrained_models/hub/checkpoints/metric_video_depth_anything_vitl.pth`
 
 These files can be downloaded from Models section of https://huggingface.co/depth-anything .
 
 - https://huggingface.co/depth-anything/Video-Depth-Anything-Large
+- https://huggingface.co/depth-anything/Video-Depth-Anything-Base
 - https://huggingface.co/depth-anything/Metric-Video-Depth-Anything-Large
+- https://huggingface.co/depth-anything/Metric-Video-Depth-Anything-Base
+
+`VDA_Stream_*` uses the same checkpoint files as `VDA_*`.
 
 #### VDA Implementation Notes
 

--- a/iw3/gui.py
+++ b/iw3/gui.py
@@ -680,12 +680,20 @@ class MainFrame(wx.Frame):
             depth_models.append("Distill_Any_L")
 
         depth_models += ["VDA_S"]
+        if VideoDepthAnythingModel.has_checkpoint_file("VDA_B"):
+            depth_models.append("VDA_B")
         if VideoDepthAnythingModel.has_checkpoint_file("VDA_L"):
             depth_models.append("VDA_L")
-        if VideoDepthAnythingModel.has_checkpoint_file("VDA_Metric"):
-            depth_models.append("VDA_Metric")
+
+        depth_models += ["VDA_Metric_S"]
+        if VideoDepthAnythingModel.has_checkpoint_file("VDA_Metric_B"):
+            depth_models.append("VDA_Metric_B")
+        if VideoDepthAnythingModel.has_checkpoint_file("VDA_Metric_L"):
+            depth_models.append("VDA_Metric_L")
 
         depth_models += ["VDA_Stream_S"]
+        if VideoDepthAnythingStreamingModel.has_checkpoint_file("VDA_Stream_B"):
+            depth_models.append("VDA_Stream_B")
         if VideoDepthAnythingStreamingModel.has_checkpoint_file("VDA_Stream_L"):
             depth_models.append("VDA_Stream_L")
 

--- a/iw3/utils.py
+++ b/iw3/utils.py
@@ -1689,8 +1689,9 @@ def create_parser(required_true=True):
                                  "Any_V2_K_S", "Any_V2_K_B", "Any_V2_K_L",
                                  "Distill_Any_S", "Distill_Any_B", "Distill_Any_L",
                                  "DepthPro", "DepthPro_S",
-                                 "VDA_S", "VDA_L", "VDA_Metric",
-                                 "VDA_Stream_S", "VDA_Stream_L",
+                                 "VDA_S", "VDA_B", "VDA_L",
+                                 "VDA_Metric", "VDA_Metric_S", "VDA_Metric_B", "VDA_Metric_L",
+                                 "VDA_Stream_S", "VDA_Stream_B", "VDA_Stream_L",
                                  "NULL",
                                  ],
                         help="depth model name")

--- a/iw3/video_depth_anything_model.py
+++ b/iw3/video_depth_anything_model.py
@@ -14,19 +14,37 @@ from .models import DepthAA
 
 NAME_MAP = {
     "VDA_S": "vits",
+    "VDA_B": "vitb",
     "VDA_L": "vitl",
-    "VDA_Metric": "vitl",
+    "VDA_Metric": "vitl",  # old ver compatibility
+    "VDA_Metric_S": "vits",
+    "VDA_Metric_B": "vitb",
+    "VDA_Metric_L": "vitl",
 }
 MODEL_FILES = {
     "VDA_S": path.join(HUB_MODEL_DIR, "checkpoints", "video_depth_anything_vits.pth"),
+    "VDA_B": path.join(HUB_MODEL_DIR, "checkpoints", "video_depth_anything_vitb.pth"),
     "VDA_L": path.join(HUB_MODEL_DIR, "checkpoints", "video_depth_anything_vitl.pth"),
     "VDA_Metric": path.join(HUB_MODEL_DIR, "checkpoints", "metric_video_depth_anything_vitl.pth"),
+    "VDA_Metric_S": path.join(HUB_MODEL_DIR, "checkpoints", "metric_video_depth_anything_vits.pth"),
+    "VDA_Metric_B": path.join(HUB_MODEL_DIR, "checkpoints", "metric_video_depth_anything_vitb.pth"),
+    "VDA_Metric_L": path.join(HUB_MODEL_DIR, "checkpoints", "metric_video_depth_anything_vitl.pth"),
 }
 METRIC_PADDING = 14
 AA_SUPPORT_MODELS = {
     "VDA_S",
+    "VDA_B",
     "VDA_L",
     "VDA_Metric",
+    "VDA_Metric_S",
+    "VDA_Metric_B",
+    "VDA_Metric_L",
+}
+METRIC_DEPTH_TYPES = {
+    "VDA_Metric",
+    "VDA_Metric_S",
+    "VDA_Metric_B",
+    "VDA_Metric_L",
 }
 
 
@@ -92,7 +110,7 @@ class VideoDepthAnythingModel(BaseDepthModel):
         self.depth_aa = DepthAA().load().eval().to(device)
         # load depth model
         encoder = NAME_MAP[model_type]
-        if model_type == "VDA_Metric":
+        if model_type in METRIC_DEPTH_TYPES:
             # MetricVideoDepthAnything
             if not os.getenv("IW3_DEBUG"):
                 model = torch.hub.load("nagadomi/Video-Depth-Anything_iw3:main",
@@ -235,7 +253,7 @@ class VideoDepthAnythingModel(BaseDepthModel):
         if self.model is not None:
             return self.model.metric_depth
         else:
-            return self.model_type == "VDA_Metric"
+            return self.model_type in METRIC_DEPTH_TYPES
 
     @classmethod
     def multi_gpu_supported(cls, model_type):

--- a/iw3/video_depth_anything_streaming_model.py
+++ b/iw3/video_depth_anything_streaming_model.py
@@ -12,14 +12,17 @@ from .models import DepthAA
 
 NAME_MAP = {
     "VDA_Stream_S": "vits",
+    "VDA_Stream_B": "vitb",
     "VDA_Stream_L": "vitl",
 }
 MODEL_FILES = {
     "VDA_Stream_S": path.join(HUB_MODEL_DIR, "checkpoints", "video_depth_anything_vits.pth"),
+    "VDA_Stream_B": path.join(HUB_MODEL_DIR, "checkpoints", "video_depth_anything_vitb.pth"),
     "VDA_Stream_L": path.join(HUB_MODEL_DIR, "checkpoints", "video_depth_anything_vitl.pth"),
 }
 AA_SUPPORT_MODELS = {
     "VDA_Stream_S",
+    "VDA_Stream_B",
     "VDA_Stream_L",
 }
 


### PR DESCRIPTION
- Add the recently released Video Depth Anything models. `VDA_B`, `VDA_Metric_S`, `VDA_Metric_B`, `VDA_Stream_B`.
- Rename `VDA_Metric` to `VDA_Metric_L`. `VDA_Metric` can still be used for compatibility.

The base model is licensed under cc-by-nc-4.0 so download it yourself if you want to use it.
See the updated README.md for details.

---

On Linux, the VideoDepthAnything code needs to be updated using the following command.
```
python -m iw3.download_models
```
