### PR TITLE
iw3: Fix mlbw_l2s disabling preserve_screen_border in GUI

### DIFF
--- a/iw3/gui.py
+++ b/iw3/gui.py
@@ -844,7 +844,7 @@ class MainFrame(wx.Frame):
 
     def update_preserve_screen_border(self):
         if self.cbo_method.GetValue() in {"row_flow_v2", "row_flow_v3", "row_flow_v3_sym",
-                                          "mlbw_l2", "mlbw_l4"}:
+                                          "mlbw_l2", "mlbw_l2s", "mlbw_l4"}:
             self.chk_preserve_screen_border.Enable()
         else:
             self.chk_preserve_screen_border.Disable()


### PR DESCRIPTION
mlbw_l2s was added later, so it was missing.
Fix #476