### PR TITLE
Fix test_audio_copy() failed on formats other than mp4

### DIFF
--- a/nunif/utils/video.py
+++ b/nunif/utils/video.py
@@ -744,11 +744,11 @@ def try_replace(output_path_tmp, output_path):
 
 def test_audio_copy(input_path, output_path):
     buff = io.BytesIO()
-    container_format = path.splitext(output_path)[-1][1:]
+    buff.name = path.basename(output_path)
     try:
         with (
                 av.open(input_path) as input_container,
-                av.open(buff, mode="w", format=container_format) as output_container,
+                av.open(buff, mode="w") as output_container,
         ):
             if len(input_container.streams.audio) > 0:
                 audio_input_stream = input_container.streams.audio[0]


### PR DESCRIPTION
Fix #480

[PyAV refers to file_.name](https://github.com/PyAV-Org/PyAV/blob/4d603ec63b4d4f55e2bfe97bd2dd0f04cb41f361/av/container/core.pyx#L212-L215) and uses `av_guess_format()` internally.
