### PR TITLE
Continue to decode even if some frame in the video is corrupted (mimicking ffmpeg behaviour)

### DIFF
--- a/nunif/utils/video.py
+++ b/nunif/utils/video.py
@@ -14,6 +14,7 @@ from concurrent.futures import ThreadPoolExecutor
 from fractions import Fraction
 import time
 import numpy as np
+import sys
 
 
 # Add video mimetypes that does not exist in mimetypes
@@ -767,6 +768,15 @@ def test_audio_copy(input_path, output_path):
         return True
 
 
+def safe_decode(packet):
+    try:
+        frames = packet.decode()
+    except av.error.InvalidDataError:
+        frames = []
+        print("\n[WARN] Input video has invalid data/frames! continuing anyway...", file=sys.stderr)
+    return frames
+
+
 def process_video(input_path, output_path,
                   frame_callback,
                   config_callback=default_config_callback,
@@ -867,12 +877,7 @@ def process_video(input_path, output_path,
             if end_time is not None and packet.stream.type == "video" and end_time < packet.pts * packet.time_base:
                 break
         if packet.stream.type == "video":
-            try:
-                frames = packet.decode()
-            except:
-                frames = []
-                print("[WARN] packet.decode failed! input video may be corrupted but continuing anyway!")
-            for frame in frames:
+            for frame in safe_decode(packet):
                 frame = fps_filter.update(frame)
                 if frame is not None:
                     frame = frame.reformat(**rgb24_options) if rgb24_options else frame
@@ -889,7 +894,7 @@ def process_video(input_path, output_path,
                     packet.stream = audio_output_stream
                     output_container.mux(packet)
                 else:
-                    for frame in packet.decode():
+                    for frame in safe_decode(packet):
                         frame.pts = None
                         enc_packet = audio_output_stream.encode(frame)
                         if enc_packet:
@@ -996,7 +1001,7 @@ def generate_video(output_path,
                         packet.stream = audio_output_stream
                         output_container.mux(packet)
                     else:
-                        for frame in packet.decode():
+                        for frame in safe_decode(packet):
                             frame.pts = None
                             enc_packet = audio_output_stream.encode(frame)
                             if enc_packet:
@@ -1126,7 +1131,7 @@ def hook_frame(input_path,
         if packet.pts is not None:
             if end_time is not None and packet.stream.type == "video" and end_time < packet.pts * packet.time_base:
                 break
-        for frame in packet.decode():
+        for frame in safe_decode(packet):
             frame = fps_filter.update(frame)
             if frame is not None:
                 frame = frame.reformat(**rgb24_options) if rgb24_options else frame
@@ -1210,7 +1215,7 @@ def export_audio(input_path, output_path, start_time=None, end_time=None,
                 packet.stream = audio_output_stream
                 output_container.mux(packet)
             else:
-                for frame in packet.decode():
+                for frame in safe_decode(packet):
                     frame.pts = None
                     enc_packet = audio_output_stream.encode(frame)
                     if enc_packet:


### PR DESCRIPTION
### Issues:

I have old videos that I wish to convert to 3D, but some of them are unfortunately corrupted because of unknown reasons (probably recording, downloading, or storage error).

#### Video decode behavior (current situation):
Throws error and exit immediately! 🥀
<img width="2560" height="480" alt="Screenshot_20251125_043723" src="https://github.com/user-attachments/assets/fcd349f5-b1ab-46ac-8e85-0184b29d32c1" />

#### Video decode behaviour in ffmpeg:
Show some warnings, skip corrupted frame and decode the rest of video! 👍
<img width="2560" height="868" alt="Screenshot_20251125_044857" src="https://github.com/user-attachments/assets/2b9dcfb4-7f7b-4548-ba66-38886b4abca6" />
---
I've found more than 9 old videos from at least two different sources behaving this way. 🔍

### The solution I proposed:

Tiny change to the `./nunif/utils/video.py` code (line `870`-`875`) but very effective of mimicking ffmpeg behavior (only show warning and continue decoding). 📝

<img width="2439" height="337" alt="Screenshot_20251125_045040" src="https://github.com/user-attachments/assets/9077d325-56e3-4849-9e2b-8ff9d97afd2f" />

### Possible further improvement that could be made (Discussions):

If the "error and exit immediately" is desired in some cases(?) would it be nice to create new argument like "`--skip-frame-error`" or "`--force-continue-decoding`" to mimicking the ffmpeg behavior? or merge this PR if proposed ffmpeg-like behavior is accepted for all cases(?) 🤔