### PR TITLE
Add more rule to determine if output type is a directory

### DIFF
--- a/iw3/utils.py
+++ b/iw3/utils.py
@@ -876,7 +876,9 @@ def process_video_full(input_filename, output_path, args, depth_model, side_mode
     ):
         side_model = compile_model(side_model)
 
-    if is_output_dir(output_path):
+    output_parent_dir = path.basename(output_path)
+    input_parent_dir = path.basename(path.dirname(input_filename))
+    if is_output_dir(output_path) or (output_parent_dir != "" and output_parent_dir == input_parent_dir):
         os.makedirs(output_path, exist_ok=True)
         output_filename = path.join(
             output_path,


### PR DESCRIPTION
Sorry for frequent PR but again, I found a minor but annoying bug 🥀
### Issue 📝:
Here is an example where the old logic to determine if the output type is folder fail 👀:
File (for example): `/home/tjandra/video/2025.02.07/test.mp4` exist and valid video file
Content of `/home/tjandra/video3D/` should be empty (no `2025.02.07` folder inside)
Command (for example): `python -m iw3  --resume --recursive ... -i /home/tjandra/video/ -o /home/tjandra/video3D/`
This is where the logic fail, it will output `/home/tjandra/video/2025.02.07` (as file!) that will throw `ValueError: Could not determine output format`
Variable value 🔍:
- `input_filename` = `/home/tjandra/video/2025.02.07/test.mp4`
- `output_path` = `/home/tjandra/video/2025.02.07`
- `output_filename` = `/home/tjandra/video/2025.02.07` (wrong!)
### Proposed solution (simplest) 💡:
Check parent directory of `input_filename`, for above example it's `2025.02.07` from `/home/tjandra/video/`_**2025.02.07**_`/test.mp4`
Then check leaf directory name (or filename) of `output_path`, for above example it's `2025.02.07` from `/home/tjandra/video/`_**2025.02.07**_
If both of them match then it will assume that output type is a directory 📁
### Improvement that could be made 💭:
I know this simplest solution also has a bug, but to trigger the bug the parent folder name of input filename must exactly match the output filename + its extension which is extremely rare(?) compared to current bug that the there should be a dot in the leaf folder name to trigger it 😅
`nunif/utils/ui.py` line `61` could be better(?):
<img width="1800" height="101" alt="Screenshot_20251128_132933" src="https://github.com/user-attachments/assets/5ca6f2b0-1827-4242-9643-9a1d67893609" />
I admit this bug is quite rare too because I found it after days of converting videos 👀