### PR TITLE
Ignore metadata error when opening input video container

### DIFF
--- a/nunif/utils/video.py
+++ b/nunif/utils/video.py
@@ -844,7 +844,7 @@ def process_video(input_path, output_path,
             raise ValueError("end_time must be greater than start_time")
 
     output_path_tmp = path.join(path.dirname(output_path), "_tmp_" + path.basename(output_path))
-    input_container = av.open(input_path)
+    input_container = av.open(input_path,metadata_errors='ignore')
 
     if input_container.duration:
         container_duration = float(input_container.duration / av.time_base)


### PR DESCRIPTION
### Issues 📝:
The batch process stopped when container data contain invalid/corrupted unicode symbol 🥀:
<img width="2089" height="293" alt="Screenshot_20251212_091807" src="https://github.com/user-attachments/assets/db0252c2-941f-4e47-839f-691f8028326a" />
Similar to previous pull request, this error could be safely ignored and decode the video data anyway, just like pull https://github.com/nagadomi/nunif/pull/543 👍

### Proposed solution 💡:
Taken from here: https://github.com/PyAV-Org/PyAV/issues/1107#issuecomment-1477274807 ✅
<img width="1992" height="85" alt="Screenshot_20251212_092524" src="https://github.com/user-attachments/assets/f59a2e63-5fb2-4550-be2f-776879b43a30" />
### Improvement that could be made (Discussion) 💭:
We don't care about video container metadata right? 🤔
I think we should only care about the content of the video 👀