### PR TITLE
Change default video encoding settings

### DIFF
--- a/iw3/utils.py
+++ b/iw3/utils.py
@@ -1915,7 +1915,7 @@ def create_parser(required_true=True):
                         help="constant quality value for video. smaller value is higher quality")
     parser.add_argument("--video-bitrate", type=str, default="8M",
                         help="bitrate option for libopenh264")
-    parser.add_argument("--preset", type=str, default="ultrafast",
+    parser.add_argument("--preset", type=str, default="medium",
                         choices=["ultrafast", "superfast", "veryfast", "faster", "fast",
                                  "medium", "slow", "slower", "veryslow", "placebo",
                                  "p1", "p2", "p3", "p4", "p5", "p6", "p7"],
@@ -2070,8 +2070,7 @@ def create_parser(required_true=True):
                         choices=["divergence", "convergence", "foreground-scale", "ipd-offset"],
                         help="outputs results for various parameter combinations")
 
-    # TODO: Change the default value from "unspecified" to "auto"
-    parser.add_argument("--colorspace", type=str, default="unspecified",
+    parser.add_argument("--colorspace", type=str, default="auto",
                         choices=["unspecified", "auto",
                                  "bt709", "bt709-pc", "bt709-tv",
                                  "bt601", "bt601-pc", "bt601-tv",

--- a/nunif/gui/video_encoding_box.py
+++ b/nunif/gui/video_encoding_box.py
@@ -15,8 +15,8 @@ PRESET_LIBX264 = ["ultrafast", "superfast", "veryfast", "faster", "fast",
                   "medium", "slow", "slower", "veryslow", "placebo"]
 PRESET_NVENC = ["fast", "medium", "slow",
                 "p1", "p2", "p3", "p4", "p5", "p6", "p7"]
-
 PRESET_ALL = list(dict.fromkeys(PRESET_LIBX264 + PRESET_NVENC))
+PRESET_DEFAULT = "medium"
 
 CODEC_ALL = ["libx264", "libopenh264", "libx265", "h264_nvenc", "hevc_nvenc", "utvideo", "ffv1"]
 
@@ -105,7 +105,7 @@ class VideoEncodingBox():
             self.grp_video, choices=PRESET_ALL,
             name=f"{prefix}cbo_preset")
         self.cbo_preset.SetEditable(False)
-        self.cbo_preset.SetSelection(0)
+        self.cbo_preset.SetSelection(PRESET_ALL.index(PRESET_DEFAULT))
 
         self.lbl_tune = wx.StaticText(self.grp_video, label=T("Tune"))
         self.cbo_tune = wx.ComboBox(
@@ -323,16 +323,13 @@ class VideoEncodingBox():
         # preset
         if container_format in {"mp4", "mkv"}:
             preset = self.cbo_preset.GetValue()
+            default_preset = PRESET_DEFAULT
             if codec in {"libx265", "libx264", "libopenh264"}:
-                # preset
                 choices = PRESET_LIBX264
-                default_preset = "ultrafast"
             elif codec in {"h264_nvenc", "hevc_nvenc"}:
                 choices = PRESET_NVENC
-                default_preset = "medium"
             else:
                 choices = PRESET_ALL
-                default_preset = "ultrafast"
 
             self.cbo_preset.SetItems(choices)
             if preset in choices:

--- a/stlizer/main.py
+++ b/stlizer/main.py
@@ -66,9 +66,7 @@ def create_parser(required_true=True):
     parser.add_argument("--video-format", "-vf", type=str, default="mp4", choices=["mp4", "mkv", "avi"],
                         help="video container format")
     parser.add_argument("--video-codec", "-vc", type=str, default=None, help="video codec")
-
-    # TODO: Change the default value from "unspecified" to "auto"
-    parser.add_argument("--colorspace", type=str, default="unspecified",
+    parser.add_argument("--colorspace", type=str, default="auto",
                         choices=["unspecified", "auto",
                                  "bt709", "bt709-pc", "bt709-tv",
                                  "bt601", "bt601-pc", "bt601-tv",

--- a/waifu2x/ui_utils.py
+++ b/waifu2x/ui_utils.py
@@ -268,7 +268,7 @@ def create_parser(required_true=True):
                         help="constant quality value. smaller value is higher quality (video only)")
     parser.add_argument("--video-bitrate", type=str, default="8M",
                         help="bitrate option for libopenh264")
-    parser.add_argument("--preset", type=str, default="ultrafast",
+    parser.add_argument("--preset", type=str, default="medium",
                         choices=["ultrafast", "superfast", "veryfast", "faster", "fast",
                                  "medium", "slow", "slower", "veryslow", "placebo",
                                  "p1", "p2", "p3", "p4", "p5", "p6", "p7"],
@@ -279,7 +279,7 @@ def create_parser(required_true=True):
                         help="encoder tunings option (video only)")
     parser.add_argument("--pix-fmt", type=str, default="yuv420p", choices=["yuv420p", "yuv444p", "yuv420p10le", "rgb24", "gbrp", "gbrp10le", "gbrp16le"],
                         help=("pixel format (video only)"))
-    parser.add_argument("--colorspace", type=str, default="unspecified",
+    parser.add_argument("--colorspace", type=str, default="auto",
                         choices=["unspecified", "auto",
                                  "bt709", "bt709-pc", "bt709-tv",
                                  "bt601", "bt601-pc", "bt601-tv",


### PR DESCRIPTION
This PR changes the default video encoder settings (options).

- colorspace:  `unspecified` -> `auto`
- preset: `ultrafast` -> `medium`

The previous default for `colorspace` was `unspecified` to avoid errors with unknown colorspaces. Since `auto` has been used for over a year without issues and is now common among users, the default is changed to `auto`.

The previous default for `preset` was `ultrafast` for speed during early development. Since many users now handle high-resolution videos and some encoders don't support `ultrafast`, the default is changed to `medium`.