### PR TITLE
iw3: desktop: Add --screenshot wc_cuda

### DIFF
--- a/iw3/desktop/gui.py
+++ b/iw3/desktop/gui.py
@@ -56,7 +56,8 @@ os.makedirs(CONFIG_DIR, exist_ok=True)
 os.makedirs(PRESET_DIR, exist_ok=True)
 
 LAYOUT_DEBUG = False
-HAS_WINDOWS_CAPTURE = importlib.util.find_spec("windows_capture")
+HAS_WINDOWS_CAPTURE = bool(importlib.util.find_spec("windows_capture"))
+HAS_WINDOWS_CAPTURE_CUDA = bool(importlib.util.find_spec("wc_cuda")) and torch.cuda.is_available()
 
 
 myEVT_FPS = wx.NewEventType()
@@ -435,6 +436,8 @@ class MainFrame(wx.Frame):
             screenshot_backends += ["mss"]
         if HAS_WINDOWS_CAPTURE:
             screenshot_backends += ["wc_mp"]
+        if HAS_WINDOWS_CAPTURE_CUDA:
+            screenshot_backends += ["wc_cuda"]
         self.cbo_screenshot = wx.ComboBox(self.grp_processor,
                                           choices=screenshot_backends,
                                           name="cbo_screenshot")
@@ -1028,7 +1031,7 @@ class MainFrame(wx.Frame):
 
         monitor_index = int(self.cbo_monitor_index.GetValue())
         window_name = self.cbo_window_name.GetValue()
-        if self.cbo_screenshot.GetValue() not in {"wc_mp", "mss"}:
+        if self.cbo_screenshot.GetValue() not in {"wc_mp", "wc_cuda", "mss"}:
             monitor_index = 0
             window_name = None
         if not window_name:
@@ -1151,6 +1154,7 @@ class MainFrame(wx.Frame):
             self.SetStatusText(T("Error"))
             e_type, e, tb = sys.exc_info()
             message = getattr(e, "message", str(e))
+            print(e, file=sys.stderr)
             traceback.print_tb(tb)
             wx.MessageBox(message, f"{T('Error')}: {e.__class__.__name__}", wx.OK | wx.ICON_ERROR)
 
@@ -1286,7 +1290,7 @@ class MainFrame(wx.Frame):
         self.update_window_names()
 
     def update_monitor_index(self, *args, **kwargs):
-        if self.cbo_screenshot.GetValue() in {"wc_mp", "mss"}:
+        if self.cbo_screenshot.GetValue() in {"wc_mp", "wc_cuda", "mss"}:
             self.lbl_monitor_index.Show()
             self.cbo_monitor_index.Show()
         else:
@@ -1296,7 +1300,7 @@ class MainFrame(wx.Frame):
         self.GetSizer().Layout()
 
     def update_window_names(self, *args, **kwargs):
-        if self.cbo_screenshot.GetValue() in {"wc_mp", "mss"}:
+        if self.cbo_screenshot.GetValue() in {"wc_mp", "wc_cuda", "mss"}:
             self.lbl_window_name.Show()
             self.cbo_window_name.Show()
             self.btn_reload_window_name.Show()

--- a/iw3/desktop/screenshot_thread_cuda.py
+++ b/iw3/desktop/screenshot_thread_cuda.py
@@ -1,0 +1,144 @@
+import threading
+import torch
+import torch.nn.functional as F
+from collections import deque
+import time
+
+
+def resize_frame(frame, size):
+    # CHW uint8 - > CHW float
+    frame = frame.unsqueeze(0).float().div_(255.0)
+    return F.interpolate(
+        frame,
+        size=size,
+        mode="bilinear",
+        align_corners=False,
+        antialias=True,
+    ).squeeze(0)
+
+
+class ScreenshotThreadWCCUDA(threading.Thread):
+    def __init__(self, fps, frame_width, frame_height, monitor_index, window_name, device,
+                 crop_top=0, crop_left=0, crop_right=0, crop_bottom=0,
+                 **_ignore_unsupported_kwargs):
+        super().__init__(daemon=True)
+        self.frame_width = frame_width
+        self.frame_height = frame_height
+        self.monitor_index = monitor_index
+        self.window_name = window_name
+        self.crop_top = crop_top
+        self.crop_bottom = crop_bottom
+        self.crop_left = crop_left
+        self.crop_right = crop_right
+        self.device = device
+        self.frame_lock = threading.Lock()
+        self.fps_lock = threading.Lock()
+        self.frame = None
+        self.frame_unset_event = threading.Event()
+        self.frame_set_event = threading.Event()
+        self.stop_event = threading.Event()
+        self.fps_counter = deque(maxlen=120)
+        self.frame_buffer = torch.zeros((3, self.frame_height, self.frame_width), device=device, dtype=torch.float32)
+        self.frame_count = 0
+        self.tick = 0
+
+    def run(self):
+        from wc_cuda import WindowsCapture
+        if self.window_name:
+            # ignore
+            monitor_index = None
+        else:
+            # 1 origin
+            monitor_index = self.monitor_index + 1
+
+        capture = WindowsCapture(
+            cursor_capture=None,
+            draw_border=None,
+            monitor_index=monitor_index,
+            window_name=self.window_name,
+            device_id=self.device.index,
+        )
+
+        @capture.event
+        def on_frame_arrived(frame, capture_control):
+            # BGRA HWC -> RGB CHW
+            source_frame = frame.frame_buffer[..., [2, 1, 0]].permute(2, 0, 1)
+            if self.window_name and (self.crop_top > 0 or self.crop_left > 0 or self.crop_right > 0 or self.crop_bottom > 0):
+                h, w = source_frame.shape[-2:]
+                top = self.crop_top
+                bottom = h - self.crop_bottom if self.crop_bottom > 0 else h
+                left = self.crop_left
+                right = w - self.crop_right if self.crop_right > 0 else w
+                source_frame = source_frame[:, top:bottom, left:right]
+
+            if self.frame_buffer.shape != source_frame.shape:
+                if self.window_name is not None:
+                    min_h = min(self.frame_buffer.shape[1], source_frame.shape[1])
+                    min_w = min(self.frame_buffer.shape[2], source_frame.shape[2])
+                    if self.frame_count % 30 == 0:
+                        self.frame_buffer[:] = 0.0
+
+                    self.frame_buffer[:, 0:min_h, 0:min_w].copy_(source_frame[:, 0:min_h, 0:min_w]).div_(255.0)
+                    self.frame_count += 1
+                    if self.frame_count > 0xffff:
+                        self.frame_count = 0
+                else:
+                    self.frame_buffer.copy_(resize_frame(source_frame, size=self.frame_buffer.shape[-2:]))
+            else:
+                self.frame_buffer.copy_(source_frame).div_(255.0)
+
+            with self.frame_lock:
+                self.frame = self.frame_buffer
+                self.frame_set_event.set()
+                self.frame_unset_event.clear()
+
+            now = time.perf_counter()
+            if self.tick > 0:
+                process_time = now - self.tick
+                with self.fps_lock:
+                    self.fps_counter.append(process_time)
+            self.tick = now
+
+            if self.stop_event.is_set():
+                capture_control.stop()
+
+        @capture.event
+        def on_closed():
+            pass
+
+        try:
+            # event loop
+            capture.start()
+        finally:
+            self.frame_set_event.set()
+            self.frame_unset_event.clear()
+            time.sleep(0.1)
+
+    def get_frame(self):
+        while not self.frame_set_event.wait(1):
+            if not self.is_alive():
+                raise RuntimeError("thread is already dead")
+        with self.frame_lock:
+            frame = self.frame
+            self.frame = None
+            self.frame_set_event.clear()
+            self.frame_unset_event.set()
+
+        if frame is None:
+            raise RuntimeError("thread is dead")
+
+        return frame
+
+    def get_fps(self):
+        with self.fps_lock:
+            if self.fps_counter:
+                mean_processing_time = sum(self.fps_counter) / len(self.fps_counter)
+                return 1 / mean_processing_time
+            else:
+                return 0
+
+    def stop(self):
+        self.stop_event.set()
+        self.frame_unset_event.set()
+        if self.ident is not None:
+            self.join(timeout=4)

--- a/iw3/desktop/utils.py
+++ b/iw3/desktop/utils.py
@@ -19,6 +19,7 @@ from .. import utils as IW3U
 from ..stereo_model_factory import get_mlbw_divergence_level
 from .. import models  # noqa
 from .screenshot_thread_pil import ScreenshotThreadPIL
+from .screenshot_thread_cuda import ScreenshotThreadWCCUDA
 from .screenshot_process import ( # noqa
     ScreenshotProcess,
     get_monitor_size_list,
@@ -147,7 +148,7 @@ def create_parser():
     parser.add_argument("--stream-height", type=int, default=1080, help="Streaming screen resolution")
     parser.add_argument("--stream-quality", type=int, default=90, help="Streaming JPEG quality")
     parser.add_argument("--full-sbs", action="store_true", help="Use Full SBS for Pico4")
-    parser.add_argument("--screenshot", type=str, default="pil", choices=["pil", "mss", "wc_mp"],
+    parser.add_argument("--screenshot", type=str, default="pil", choices=["pil", "mss", "wc_mp", "wc_cuda"],
                         help="Screenshot method")
     parser.add_argument("--gpu-jpeg", action="store_true", help="Use GPU JPEG Encoder")
     parser.add_argument("--monitor-index", type=int, default=0, help="monitor_index for wc_mp. 0 origin. 0 = monitor 1")
@@ -254,6 +255,8 @@ def iw3_desktop_main(args, init_wxapp=True):
         screenshot_factory = lambda *args, **kwargs: ScreenshotProcess(*args, **kwargs, backend="mss")
     elif args.screenshot == "wc_mp":
         screenshot_factory = lambda *args, **kwargs: ScreenshotProcess(*args, **kwargs, backend="windows_capture")
+    elif args.screenshot == "wc_cuda":
+        screenshot_factory = lambda *args, **kwargs: ScreenshotThreadWCCUDA(*args, **kwargs)
 
     device = create_device(args.gpu)
 
@@ -368,6 +371,8 @@ def iw3_desktop_main(args, init_wxapp=True):
             with args.state["args_lock"]:
                 tick = time.perf_counter()
                 frame = screenshot_thread.get_frame()
+                if frame is None:
+                    break
                 sbs = IW3U.process_image(frame, args, depth_model, side_model, autocrop_uncrop=True)
 
                 if not args.local_viewer:

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -7,3 +7,6 @@ PyOpenGL >= 3.1.9
 # PyOpenGL_accelerate is not required, but it is recommended.
 # If installation fails, you can ignore it.
 PyOpenGL_accelerate >= 3.1.9
+
+# https://github.com/nagadomi/wc_cuda
+wc_cuda @ https://github.com/nagadomi/wc_cuda/releases/download/v0.1.0/wc_cuda-0.1.0-cp310-abi3-win_amd64.whl; sys_platform=='win32'


### PR DESCRIPTION
This PR adds a new screenshot method, `wc_cuda`, to iw3-desktop on Windows.
Unlike `wc_mp`, it avoids CPU memory copies and inter-device memory transfers.

This may significantly improve performance, although the difference might be small since it's already masked by parallel processing.
I've only tested it on an old Windows laptop (GTX 1050 ti), so the actual impact is uncertain.

If it performs slower than `wc_mp` or if you encounter any issues, please open a new issue.

---
One more note: there's still a memory transfer between the GPU and CPU in the section that renders the Local Viewer.
I plan to address this in a future update.

---
The source code for `wc_cuda` is publicly available at https://github.com/nagadomi/wc_cuda.
In this project, it is installed automatically.