### PR TITLE
iw3 alpha video processing

### DIFF
--- a/iw3/utils.py
+++ b/iw3/utils.py
@@ -228,7 +228,6 @@ def make_video_codec_option(args, input_path=None):
     if args.video_codec == "libvpx-vp9" and "a" in args.pix_fmt.lower():
         options["auto-alt-ref"] = "0"
         options["alpha_mode"] = "1"
-        print(f"\nDEBUG [CODEC OPTIONS]: Applied VP9 alpha settings. Options mapped: {options}")
 
     return options
 
@@ -937,7 +936,6 @@ def bind_batch_frame_callback(depth_model, side_model, segment_pts, args):
                 if alpha_batch is not None:
                     fill_color = torch.tensor([0.4, 0.5, 0.6], dtype=x.dtype, device=x.device).view(1, 3, 1, 1)
                     x = x * alpha_batch + fill_color * (1.0 - alpha_batch)
-                    print(f"DEBUG [INFER]: Applied gray mask to RGB tensor background.")
 
                 depth_batch = depth_model.infer(x, tta=args.tta, low_vram=args.low_vram,
                                                 enable_amp=not args.disable_amp,
@@ -958,7 +956,6 @@ def bind_batch_frame_callback(depth_model, side_model, segment_pts, args):
                         if m.any():
                             bg_depth = (depth_batch[i][m].min() + depth_batch[i].min()) * 0.5
                             depth_batch[i][torch.logical_not(m)] = bg_depth
-                            print(f"DEBUG [INFER]: Batch {i} background depth flattened to: {bg_depth.item():.4f}")
 
             return depth_batch, dequeue_ticket_id
 
@@ -1006,7 +1003,6 @@ def bind_batch_frame_callback(depth_model, side_model, segment_pts, args):
 
     def _preprocess(x, pts, flush):
         enqueue_ticket_id = enqueue_ticket_lock.new_ticket()
-        print(f"DEBUG [PROCESS: _preprocess] Incoming x shape: {getattr(x, 'shape', 'None')}")
         if not flush and x is not None and x.shape[-3] == 4:
             if x.ndim == 4:
                 alpha_batch = x[:, 3:4].contiguous()
@@ -1014,10 +1010,8 @@ def bind_batch_frame_callback(depth_model, side_model, segment_pts, args):
             else:
                 alpha_batch = x[3:4].contiguous()
                 x = x[:3].contiguous()
-            print(f"DEBUG [PROCESS: _preprocess] Alpha extracted. x: {x.shape}, alpha: {alpha_batch.shape}")
         else:
             alpha_batch = None
-            print(f"DEBUG [PROCESS: _preprocess] No alpha extracted. Condition failed.")
         return (x, pts, flush, enqueue_ticket_id, alpha_batch)
 
     return _cuda_stream_wrapper, _preprocess

--- a/iw3/utils.py
+++ b/iw3/utils.py
@@ -225,6 +225,11 @@ def make_video_codec_option(args, input_path=None):
     else:
         options = {}
 
+    if args.video_codec == "libvpx-vp9" and "a" in args.pix_fmt.lower():
+        options["auto-alt-ref"] = "0"
+        options["alpha_mode"] = "1"
+        print(f"\nDEBUG [CODEC OPTIONS]: Applied VP9 alpha settings. Options mapped: {options}")
+
     return options
 
 
@@ -727,16 +732,41 @@ def process_images(files, output_dir, args, depth_model, side_model, title=None)
 
 # video callbacks
 
+
+def extract_frame_rgb_alpha(frame, device):
+    fmt_name = frame.format.name
+    has_alpha = (
+        len(frame.format.components) == 4 or
+        "alpha" in fmt_name or
+        "yuva" in fmt_name or
+        "rgba" in fmt_name
+    )
+    if has_alpha:
+        is_16bit = frame.format.components[0].bits > 8
+        nd = frame.to_ndarray(format="rgba64le" if is_16bit else "rgba")
+        t = torch.from_numpy(nd).to(device).permute(2, 0, 1).float()
+        t /= 65535.0 if is_16bit else 255.0
+        rgb = t[:3]
+        alpha = t[3:4]
+        if torch.all(alpha == 1.0):
+            alpha = None
+        return rgb, alpha
+    else:
+        return VU.to_tensor(frame, device=device), None
+
+
 def bind_single_frame_callback(depth_model, side_model, segment_pts, args):
     src_queue = []
     frame_cpu_offload = depth_model.get_ema_buffer_size() > 1
 
     def _postprocess(depths, flush):
         for depth in depths:
-            x, pts = src_queue.pop(0)
+            x, alpha, pts = src_queue.pop(0)
             reset_pts = [pts in segment_pts]
             if isinstance(x, VU.OffloadFrame):
                 x = x.load(device=args.state["device"])
+            if alpha is not None:
+                alpha = alpha.to(args.state["device"])
             if args.debug_depth:
                 out = debug_depth_image(depth, args)
             elif args.rgbd or args.half_rgbd:
@@ -746,7 +776,18 @@ def bind_single_frame_callback(depth_model, side_model, segment_pts, args):
                 left_eye, right_eye = apply_divergence(depth, x, args, side_model, reset_pts=reset_pts)
                 if left_eye is not None:
                     if left_eye.ndim == 3:
-                        out = postprocess_image(left_eye, right_eye, args)
+                        sbs_rgb = postprocess_image(left_eye, right_eye, args)
+                        if alpha is not None:
+                            left_alpha, right_alpha = apply_divergence(
+                                depth, alpha.repeat(3, 1, 1), args, side_model, reset_pts=reset_pts)
+                            if left_alpha is not None:
+                                sbs_alpha = postprocess_image(
+                                    left_alpha, right_alpha, args).mean(dim=0, keepdim=True)
+                                out = torch.cat([sbs_rgb, sbs_alpha], dim=0)
+                            else:
+                                out = sbs_rgb
+                        else:
+                            out = sbs_rgb
                     else:
                         out = [postprocess_image(left, right, args) for left, right in zip(left_eye, right_eye)]
                 else:
@@ -780,14 +821,14 @@ def bind_single_frame_callback(depth_model, side_model, segment_pts, args):
             yield from _postprocess(depth_model.flush_minmax_normalize(), flush=True)
             return
 
-        pix_dtype = VU.get_source_dtype(frame)
-        x = VU.to_tensor(frame, device=args.state["device"])
+        x, alpha = extract_frame_rgb_alpha(frame, args.state["device"])
         if frame_cpu_offload:
+            pix_dtype = VU.get_source_dtype(frame)
             # cpu buffer
-            src_queue.append((VU.OffloadFrame(x, dtype=pix_dtype), frame.pts))
+            src_queue.append((VU.OffloadFrame(x, dtype=pix_dtype), alpha.cpu() if alpha is not None else None, frame.pts))
         else:
             # gpu buffer
-            src_queue.append((x, frame.pts))
+            src_queue.append((x, alpha, frame.pts))
 
         depth = depth_model.infer(x, tta=args.tta, low_vram=args.low_vram,
                                   enable_amp=not args.disable_amp,
@@ -831,31 +872,52 @@ def bind_batch_frame_callback(depth_model, side_model, segment_pts, args):
                     depths = depths.to(device)
                 if frame_cpu_offload:
                     x_srcs = []
+                    alpha_srcs = []
                     pts = []
                     for _ in range(len(depths)):
-                        x_src, t = src_queue.pop(0)
+                        x_src, alpha_i, t = src_queue.pop(0)
                         x_srcs.append(x_src.load(device=device))
+                        alpha_srcs.append(alpha_i.to(device) if alpha_i is not None else None)
                         pts.append(t)
                     x_srcs = torch.stack(x_srcs)
+                    has_alpha = alpha_srcs[0] is not None
+                    alpha_srcs = torch.stack(alpha_srcs) if has_alpha else None
                 else:
-                    x_srcs, pts = src_queue.pop(0)
+                    x_srcs, alpha_srcs, pts = src_queue.pop(0)
+                    has_alpha = alpha_srcs is not None
                 reset_pts = [t in segment_pts for t in pts]
 
                 with sbs_lock:  # TODO: unclear whether this is actually needed
                     if args.rgbd or args.half_rgbd:
                         left_eyes, right_eyes = apply_rgbd(x_srcs, depths, mapper=args.mapper)
+                        left_alphas = right_alphas = None
                     else:
                         if args.method in {"forward_fill", "forward"}:
                             # lock all threads (sbs_lock -> ticket_lock -> depth_lock order)
                             with enqueue_ticket_lock, dequeue_ticket_lock, depth_lock:
                                 left_eyes, right_eyes = apply_divergence(depths, x_srcs, args, side_model, reset_pts=reset_pts)
+                                if has_alpha:
+                                    left_alphas, right_alphas = apply_divergence(
+                                        depths, alpha_srcs.repeat(1, 3, 1, 1), args, side_model, reset_pts=reset_pts)
+                                else:
+                                    left_alphas = right_alphas = None
                         else:
                             left_eyes, right_eyes = apply_divergence(depths, x_srcs, args, side_model, reset_pts=reset_pts)
+                            if has_alpha:
+                                left_alphas, right_alphas = apply_divergence(
+                                    depths, alpha_srcs.repeat(1, 3, 1, 1), args, side_model, reset_pts=reset_pts)
+                            else:
+                                left_alphas = right_alphas = None
 
                 for i in range(left_eyes.shape[0]):
-                    yield postprocess_image(left_eyes[i], right_eyes[i], args)
+                    sbs = postprocess_image(left_eyes[i], right_eyes[i], args)
+                    if left_alphas is not None and i < left_alphas.shape[0]:
+                        sbs_alpha = postprocess_image(left_alphas[i], right_alphas[i], args).mean(dim=0, keepdim=True)
+                        yield torch.cat([sbs, sbs_alpha], dim=0)
+                    else:
+                        yield sbs
 
-    def _batch_infer(x, pts, flush, enqueue_ticket_id):
+    def _batch_infer(x, pts, flush, enqueue_ticket_id, alpha_batch=None):
         # Reorder threads
         with enqueue_ticket_lock(enqueue_ticket_id):
             dequeue_ticket_id = dequeue_ticket_lock.new_ticket()
@@ -863,23 +925,46 @@ def bind_batch_frame_callback(depth_model, side_model, segment_pts, args):
                 if frame_cpu_offload:
                     pix_dtype = torch.uint16 if use_16bit else torch.uint8
                     for i in range(len(pts)):
-                        src_queue.append((VU.OffloadFrame(x[i], dtype=pix_dtype), pts[i]))
+                        alpha_i = alpha_batch[i] if alpha_batch is not None else None
+                        src_queue.append((VU.OffloadFrame(x[i], dtype=pix_dtype), alpha_i, pts[i]))
                 else:
-                    src_queue.append((x, pts))
+                    src_queue.append((x, alpha_batch, pts))
 
         if flush:
             return None, dequeue_ticket_id
         else:
             with depth_lock:
+                if alpha_batch is not None:
+                    fill_color = torch.tensor([0.4, 0.5, 0.6], dtype=x.dtype, device=x.device).view(1, 3, 1, 1)
+                    x = x * alpha_batch + fill_color * (1.0 - alpha_batch)
+                    print(f"DEBUG [INFER]: Applied gray mask to RGB tensor background.")
+
                 depth_batch = depth_model.infer(x, tta=args.tta, low_vram=args.low_vram,
                                                 enable_amp=not args.disable_amp,
                                                 edge_dilation=args.edge_dilation,
                                                 depth_aa=args.depth_aa)
+
+                if alpha_batch is not None:
+                    depth_alpha = F.interpolate(
+                        alpha_batch,
+                        size=depth_batch.shape[-2:],
+                        mode="bilinear",
+                        align_corners=False,
+                        antialias=True,
+                    )
+                    mask = depth_alpha > 0.0
+                    for i in range(depth_batch.shape[0]):
+                        m = mask[i]
+                        if m.any():
+                            bg_depth = (depth_batch[i][m].min() + depth_batch[i].min()) * 0.5
+                            depth_batch[i][torch.logical_not(m)] = bg_depth
+                            print(f"DEBUG [INFER]: Batch {i} background depth flattened to: {bg_depth.item():.4f}")
+
             return depth_batch, dequeue_ticket_id
 
     @torch.inference_mode()
     def _cuda_stream_wrapper(preprocess_args):
-        x, pts, flush, enqueue_ticket_id = preprocess_args
+        x, pts, flush, enqueue_ticket_id, alpha_batch = preprocess_args
         if flush:
             device = args.state["device"]
             reset_ema = None
@@ -904,11 +989,11 @@ def bind_batch_frame_callback(depth_model, side_model, segment_pts, args):
                 stream.wait_stream(torch.cuda.current_stream(x.device))
                 with torch.cuda.device(x.device), torch.cuda.stream(stream):
                     depth_batch, dequeue_ticket_id = _batch_infer(
-                        x, pts, flush=flush, enqueue_ticket_id=enqueue_ticket_id)
+                        x, pts, flush=flush, enqueue_ticket_id=enqueue_ticket_id, alpha_batch=alpha_batch)
                     stream.synchronize()
             else:
                 depth_batch, dequeue_ticket_id = _batch_infer(
-                    x, pts, flush=flush, enqueue_ticket_id=enqueue_ticket_id)
+                    x, pts, flush=flush, enqueue_ticket_id=enqueue_ticket_id, alpha_batch=alpha_batch)
 
             results = _postprocess(
                 depth_batch, reset_ema,
@@ -921,7 +1006,19 @@ def bind_batch_frame_callback(depth_model, side_model, segment_pts, args):
 
     def _preprocess(x, pts, flush):
         enqueue_ticket_id = enqueue_ticket_lock.new_ticket()
-        return (x, pts, flush, enqueue_ticket_id)
+        print(f"DEBUG [PROCESS: _preprocess] Incoming x shape: {getattr(x, 'shape', 'None')}")
+        if not flush and x is not None and x.shape[-3] == 4:
+            if x.ndim == 4:
+                alpha_batch = x[:, 3:4].contiguous()
+                x = x[:, :3].contiguous()
+            else:
+                alpha_batch = x[3:4].contiguous()
+                x = x[:3].contiguous()
+            print(f"DEBUG [PROCESS: _preprocess] Alpha extracted. x: {x.shape}, alpha: {alpha_batch.shape}")
+        else:
+            alpha_batch = None
+            print(f"DEBUG [PROCESS: _preprocess] No alpha extracted. Condition failed.")
+        return (x, pts, flush, enqueue_ticket_id, alpha_batch)
 
     return _cuda_stream_wrapper, _preprocess
 
@@ -2279,7 +2376,7 @@ def create_parser(required_true=True):
     parser.add_argument("--rgbd", action="store_true", help="output in RGBD")
     parser.add_argument("--half-rgbd", action="store_true", help="output in Half RGBD")
 
-    parser.add_argument("--pix-fmt", type=str, default="yuv420p", choices=["yuv420p", "yuv444p", "yuv420p10le", "rgb24", "gbrp", "gbrp10le", "gbrp16le"],
+    parser.add_argument("--pix-fmt", type=str, default="yuv420p", choices=["yuv420p", "yuv444p", "yuv420p10le", "rgb24", "gbrp", "gbrp10le", "gbrp16le", "yuva420p", "rgba", "gbrap", "gbrap10le", "gbrap16le"],
                         help="pixel format (video only)")
     parser.add_argument("--tta", action="store_true",
                         help="Use flip augmentation on depth model")

--- a/iw3/utils.py
+++ b/iw3/utils.py
@@ -733,6 +733,9 @@ def process_images(files, output_dir, args, depth_model, side_model, title=None)
 
 
 def extract_frame_rgb_alpha(frame, device):
+    if not hasattr(frame, "format"):
+        return VU.to_tensor(frame, device=device), None
+
     fmt_name = frame.format.name
     has_alpha = (
         len(frame.format.components) == 4 or

--- a/nunif/utils/shot_boundary_detection.py
+++ b/nunif/utils/shot_boundary_detection.py
@@ -54,6 +54,8 @@ def detect_boundary(
 
     def batch_callback(x, pts):
         frame_count[0] += x.shape[0]
+        if x.shape[1] == 4:
+            x = x[:, :3, :, :]
         pts = torch.tensor(pts, dtype=torch.long)
         if x.shape[0] < padding_size:
             n = padding_size - x.shape[0]

--- a/nunif/utils/video/color_transform.py
+++ b/nunif/utils/video/color_transform.py
@@ -606,8 +606,6 @@ class InputTransform:
         if has_alpha:
             target_format = "rgba64le" if "48" in self.rgb_format or "16" in self.rgb_format or self.use_16bit else "rgba"
 
-        print(f"DEBUG LOG [InputTransform]: has_alpha={has_alpha} | target_format={target_format}")
-
         frame = frame.reformat(
             format=target_format,
             src_colorspace=self.src_colorspace,
@@ -619,7 +617,6 @@ class InputTransform:
         )
 
         rgb_np: np.ndarray = frame.to_ndarray(format=target_format)
-        print(f"DEBUG LOG [InputTransform]: rgb_np.shape={rgb_np.shape}")
 
         rgb = torch.from_numpy(rgb_np).contiguous()
         rgb = rgb.to(self.device)
@@ -727,7 +724,6 @@ class OutputTransform:
         return self.from_video_frame(frame)
 
     def from_tensor(self, x: torch.Tensor) -> av.VideoFrame:
-        print(f"DEBUG [WRITE: from_tensor] Outgoing shape: {x.shape} | dst_pix_fmt: {self.dst_pix_fmt}")
         dtype: Any
         value_scale: float
         # NOTE: When using uint8, calling contiguous() is faster,
@@ -864,7 +860,6 @@ def to_tensor(frame: av.VideoFrame | TensorFrame, device: torch.device | str | N
         x = frame.to_chw()
         if device is not None:
             x = x.to(device)
-        print(f"DEBUG [READ: to_tensor] TensorFrame path. Shape: {x.shape}")
         return x
     elif isinstance(frame, av.VideoFrame):
         if device is not None:
@@ -872,7 +867,6 @@ def to_tensor(frame: av.VideoFrame | TensorFrame, device: torch.device | str | N
                 device = torch.device(device)
             if frame.format.name in {"nv12", "p010le"} and is_discrete_device(device):
                 out = ColorTransform.to_tensor(frame, device=device).squeeze(0)
-                print(f"DEBUG [READ: to_tensor] Hardware path. Shape: {out.shape}")
                 return out
 
         nd = to_ndarray(frame)
@@ -880,7 +874,6 @@ def to_tensor(frame: av.VideoFrame | TensorFrame, device: torch.device | str | N
         if device is not None:
             x = x.to(device)
         out = x.permute(2, 0, 1).contiguous().float() / float(torch.iinfo(x.dtype).max)
-        print(f"DEBUG [READ: to_tensor] Software path. ndarray: {nd.shape}, Final Tensor: {out.shape}")
         return out
     else:
         raise ValueError(f"{type(frame)} not supported")

--- a/nunif/utils/video/color_transform.py
+++ b/nunif/utils/video/color_transform.py
@@ -601,20 +601,29 @@ class InputTransform:
         )
 
     def to_tensor_av(self, frame: av.VideoFrame) -> TensorFrame:
+        has_alpha = getattr(frame.format, 'has_alpha', False) or 'a' in frame.format.name.lower() or len(frame.format.components) == 4
+        target_format = self.rgb_format
+        if has_alpha:
+            target_format = "rgba64le" if "48" in self.rgb_format or "16" in self.rgb_format or self.use_16bit else "rgba"
+
+        print(f"DEBUG LOG [InputTransform]: has_alpha={has_alpha} | target_format={target_format}")
+
         frame = frame.reformat(
-            format=self.rgb_format,
+            format=target_format,
             src_colorspace=self.src_colorspace,
             src_color_range=self.src_color_range,
             dst_colorspace=self.dst_colorspace,
             dst_color_primaries=self.dst_color_primaries,
             dst_color_trc=self.dst_color_trc,
-            dst_color_range=ColorRange.JPEG,  # full range
+            dst_color_range=ColorRange.JPEG,
         )
-        # Type ignored because to_ndarray is Any
-        rgb_np: np.ndarray = frame.to_ndarray(format=self.rgb_format)
+
+        rgb_np: np.ndarray = frame.to_ndarray(format=target_format)
+        print(f"DEBUG LOG [InputTransform]: rgb_np.shape={rgb_np.shape}")
+
         rgb = torch.from_numpy(rgb_np).contiguous()
         rgb = rgb.to(self.device)
-        # Normalize based on bit depth
+        
         if rgb_np.dtype == np.uint8:
             rgb = rgb.permute(2, 0, 1).to(self.dtype) / 255.0
         elif rgb_np.dtype == np.uint16:
@@ -704,16 +713,21 @@ class OutputTransform:
     def from_ndarray(self, x: np.ndarray) -> av.VideoFrame:
         format: str
         if x.dtype == np.uint8:
-            format = "rgb24"
+            format = "rgba" if x.shape[-1] == 4 else "rgb24"
         elif x.dtype == np.uint16:
-            format = "gbrp16le"
+            format = "rgba64le" if x.shape[-1] == 4 else "gbrp16le"
         else:
             raise ValueError(f"unsupported dtype {x.dtype}")
+
+        # Force target to preserve alpha if incoming array has alpha
+        if x.shape[-1] == 4 and self.dst_pix_fmt == "yuv420p":
+            self.dst_pix_fmt = "yuva420p"
 
         frame = av.VideoFrame.from_ndarray(x, format=format)
         return self.from_video_frame(frame)
 
     def from_tensor(self, x: torch.Tensor) -> av.VideoFrame:
+        print(f"DEBUG [WRITE: from_tensor] Outgoing shape: {x.shape} | dst_pix_fmt: {self.dst_pix_fmt}")
         dtype: Any
         value_scale: float
         # NOTE: When using uint8, calling contiguous() is faster,
@@ -733,6 +747,11 @@ class OutputTransform:
         return self.from_ndarray(x_nd)
 
     def is_dlpack_supported(self, x) -> bool:
+        # Abort GPU acceleration path if the tensor has an alpha channel
+        has_alpha = (x.shape[0] == 4) if x.dim() == 3 else (x.shape[1] == 4)
+        if has_alpha:
+            return False
+
         return (
             is_nvidia_gpu(x.device)  # TODO: Remove this condition for xpu/mps
             and self.dst_pix_fmt in {"nv12", "p010le", "yuv420p", "yuvj420p", "yuv420p10le"}
@@ -830,7 +849,13 @@ def to_ndarray(frame: av.VideoFrame) -> np.ndarray:
     from .utils import RGB_8BIT, RGB_16BIT
 
     use_16bit = frame.format.components[0].bits > 8
-    format = RGB_16BIT if use_16bit else RGB_8BIT
+    has_alpha = getattr(frame.format, 'has_alpha', False) or 'a' in frame.format.name.lower()
+
+    if has_alpha:
+        format = "rgba64le" if use_16bit else "rgba"
+    else:
+        format = RGB_16BIT if use_16bit else RGB_8BIT
+
     return frame.to_ndarray(format=format)
 
 
@@ -839,20 +864,24 @@ def to_tensor(frame: av.VideoFrame | TensorFrame, device: torch.device | str | N
         x = frame.to_chw()
         if device is not None:
             x = x.to(device)
+        print(f"DEBUG [READ: to_tensor] TensorFrame path. Shape: {x.shape}")
         return x
     elif isinstance(frame, av.VideoFrame):
         if device is not None:
             if isinstance(device, str):
                 device = torch.device(device)
             if frame.format.name in {"nv12", "p010le"} and is_discrete_device(device):
-                # Optimized path: Upload YUV to GPU via DLPack and convert to RGB on GPU
-                return ColorTransform.to_tensor(frame, device=device).squeeze(0)
+                out = ColorTransform.to_tensor(frame, device=device).squeeze(0)
+                print(f"DEBUG [READ: to_tensor] Hardware path. Shape: {out.shape}")
+                return out
 
-        x = torch.from_numpy(to_ndarray(frame))
+        nd = to_ndarray(frame)
+        x = torch.from_numpy(nd)
         if device is not None:
             x = x.to(device)
-        # CHW float32
-        return x.permute(2, 0, 1).contiguous().float() / float(torch.iinfo(x.dtype).max)
+        out = x.permute(2, 0, 1).contiguous().float() / float(torch.iinfo(x.dtype).max)
+        print(f"DEBUG [READ: to_tensor] Software path. ndarray: {nd.shape}, Final Tensor: {out.shape}")
+        return out
     else:
         raise ValueError(f"{type(frame)} not supported")
 

--- a/nunif/utils/video/processor.py
+++ b/nunif/utils/video/processor.py
@@ -265,13 +265,7 @@ def _process_video(
     video_output_stream.thread_type = "AUTO"
     video_output_stream.pix_fmt = config.pix_fmt
 
-    if config.video_codec == "libvpx-vp9" and "a" in config.pix_fmt.lower():
-        if config.options is None:
-            config.options = {}
-        config.options["alpha_mode"] = "1"
-
     video_output_stream.options = config.options
-    print(f"\nDEBUG [CONFIG]: Codec: {video_output_stream.name} | pix_fmt: {video_output_stream.pix_fmt} | Options: {video_output_stream.options}")
     video_preprocessor = VideoPreprocessor(
         stream_pix_fmt=video_input_stream.pix_fmt,
         sw_format=sw_format,
@@ -343,9 +337,7 @@ def _process_video(
                                 )
                                 uninitialized = False
                             # print(video_input_stream.format, new_frame.format, reformatted_frame.format)
-                            print(f"\nDEBUG [ENCODE]: Frame format: {reformatted_frame.format.name} | Planes: {len(reformatted_frame.planes)}")
                             enc_packets = video_output_stream.encode(reformatted_frame)
-                            print(f"DEBUG [ENCODE]: Packets generated: {len(enc_packets)}")
                             if enc_packets:
                                 output_container.mux(enc_packets)
                             pbar.update(1)
@@ -472,11 +464,6 @@ def generate_video(
     video_output_stream.pix_fmt = config.pix_fmt
     video_output_stream.width = output_size[0]
     video_output_stream.height = output_size[1]
-
-    if config.video_codec == "libvpx-vp9" and "a" in config.pix_fmt.lower():
-        if config.options is None:
-            config.options = {}
-        config.options["alpha_mode"] = "1"
 
     video_output_stream.options = config.options
 

--- a/nunif/utils/video/processor.py
+++ b/nunif/utils/video/processor.py
@@ -264,7 +264,14 @@ def _process_video(
 
     video_output_stream.thread_type = "AUTO"
     video_output_stream.pix_fmt = config.pix_fmt
+
+    if config.video_codec == "libvpx-vp9" and "a" in config.pix_fmt.lower():
+        if config.options is None:
+            config.options = {}
+        config.options["alpha_mode"] = "1"
+
     video_output_stream.options = config.options
+    print(f"\nDEBUG [CONFIG]: Codec: {video_output_stream.name} | pix_fmt: {video_output_stream.pix_fmt} | Options: {video_output_stream.options}")
     video_preprocessor = VideoPreprocessor(
         stream_pix_fmt=video_input_stream.pix_fmt,
         sw_format=sw_format,
@@ -336,7 +343,9 @@ def _process_video(
                                 )
                                 uninitialized = False
                             # print(video_input_stream.format, new_frame.format, reformatted_frame.format)
+                            print(f"\nDEBUG [ENCODE]: Frame format: {reformatted_frame.format.name} | Planes: {len(reformatted_frame.planes)}")
                             enc_packets = video_output_stream.encode(reformatted_frame)
+                            print(f"DEBUG [ENCODE]: Packets generated: {len(enc_packets)}")
                             if enc_packets:
                                 output_container.mux(enc_packets)
                             pbar.update(1)
@@ -463,6 +472,12 @@ def generate_video(
     video_output_stream.pix_fmt = config.pix_fmt
     video_output_stream.width = output_size[0]
     video_output_stream.height = output_size[1]
+
+    if config.video_codec == "libvpx-vp9" and "a" in config.pix_fmt.lower():
+        if config.options is None:
+            config.options = {}
+        config.options["alpha_mode"] = "1"
+
     video_output_stream.options = config.options
 
     if audio_file is not None:

--- a/nunif/utils/video/video_preprocessor.py
+++ b/nunif/utils/video/video_preprocessor.py
@@ -130,10 +130,14 @@ class VideoPreprocessor:
             def _reformatter(frame: av.VideoFrame) -> av.VideoFrame:
                 # Optimized transfer for software decoders when device is GPU
                 dlpack_pix_fmt = sw_format.guess_sw_dlpack_pix_fmt()
-                if dlpack_pix_fmt is not None and is_discrete_device(device) and frame.height >= 320:
+                has_alpha = getattr(frame.format, 'has_alpha', False) or 'a' in frame.format.name.lower() or len(frame.format.components) == 4
+
+                if dlpack_pix_fmt is not None and is_discrete_device(device) and frame.height >= 320 and not has_alpha:
                     dst_pix_fmt: str = dlpack_pix_fmt
                 else:
                     dst_pix_fmt = sw_format.guess_rgb_pix_fmt()
+                    if has_alpha:
+                        dst_pix_fmt = "rgba64le" if "48" in dst_pix_fmt or "16" in dst_pix_fmt else "rgba"
 
                 threads = None if frame.height >= 320 else 1
                 dst_color_trc = (


### PR DESCRIPTION
**The Problem:**
When attempting to process videos with an alpha channel (e.g., VP9 WebMs) through `iw3`, the pipeline fails to handle the 4th channel correctly:

1. **SBD Crash:** Scene Boundary Detection (`transnetv2`) explicitly asserts for a 3-channel input `(3, H, W)` and crashes immediately with an `AssertionError` when fed a 4-channel tensor.
2. **Ignored Alpha during Inference:** During video processing, `_preprocess` successfully extracts `alpha_batch`, but it is completely ignored during `depth_model.infer()`. Because the RGB background is not masked, the depth model generates erroneous depth geometry on the transparent/background pixels.

**The Solution:**

* **`nunif/utils/shot_boundary_detection.py`:** Added a check in `batch_callback` to slice `x[:, :3, :, :]` if a 4-channel tensor is detected, preventing the assertion crash while maintaining accurate scene detection.
* **`iw3/utils.py`:** * Updated `_batch_infer` to properly utilize `alpha_batch` (if present). It applies a neutral gray mask to the background of the RGB tensor *before* depth inference to prevent background geometry hallucination.
* Explicitly flattens the background depth of the mask to the maximum distance.
* Added `alpha_mode="1"` and `auto-alt-ref="0"` mapping in `make_video_codec_option` to ensure VP9 outputs properly flag the alpha channel in the container metadata.

**Testing & Reproduction:**
This was tested end-to-end on Windows utilizing a 3-step extraction and re-encoding pipeline to ensure the alpha stream is not dropped by PyAV/FFmpeg during intermediate steps.

Here is the exact PowerShell script used to verify the fix worked for a `webm` a transparent background:

```powershell
$ErrorActionPreference = "Stop"

$DownloadsDir = "$env:USERPROFILE\Downloads"
$InputWebm = "$DownloadsDir\input.webm"
$TempAlphaMkv = "$DownloadsDir\input_temp_alpha.mkv"
$TempLosslessMkv = "$DownloadsDir\output_lossless.mkv"
$OutputWebm = "$DownloadsDir\output.webm"
$PythonExe = "D:\nunif\venv\Scripts\python.exe"

# 1. Extract WebM alpha stream to lossless FFV1
ffmpeg -y -v warning -c:v libvpx-vp9 -i $InputWebm -c:v ffv1 -pix_fmt yuva420p $TempAlphaMkv

# 2. Process stereoscopic depth with iw3
Set-Location "D:\nunif"
& $PythonExe -m iw3 -i $TempAlphaMkv -o $TempLosslessMkv --pix-fmt yuva420p --depth-model Any_V2_L --scene-detect --ema-normalize --gpu 0 --video-codec ffv1

# 3. Encode final WebM with alpha metadata
ffmpeg -y -v warning -i $TempLosslessMkv -c:v libvpx-vp9 -pix_fmt yuva420p -auto-alt-ref 0 -metadata:s:v:0 alpha_mode="1" -c:a libopus $OutputWebm
```