### PR TITLE
iw3-player: fix certificate generation with current pyOpenSSL

### DIFF
--- a/iw3/player/server.py
+++ b/iw3/player/server.py
@@ -45,38 +45,47 @@ def is_loopback_address(ip):
 
 
 def generate_self_signed_cert(cert_dir, cert_file, key_file, bind_addr="127.0.0.1"):
-    from OpenSSL import crypto
+    from datetime import datetime, timedelta, timezone
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import NameOID
 
     if not os.path.exists(cert_dir):
         os.makedirs(cert_dir)
     if not os.path.exists(cert_file) or not os.path.exists(key_file):
-        k = crypto.PKey()
-        k.generate_key(crypto.TYPE_RSA, 2048)
-
-        cert = crypto.X509()
-        cert.set_version(2)  # v3
-        cert.get_subject().ST = "Tokyo"
-        cert.get_subject().L = "Local"
-        cert.get_subject().O = "My App"  # noqa: E741
-        cert.get_subject().CN = bind_addr
-        cert.set_serial_number(int(os.getpid() + os.getppid() + os.urandom(1)[0]))
-        cert.gmtime_adj_notBefore(0)
-        cert.gmtime_adj_notAfter(10 * 365 * 24 * 60 * 60)
-        cert.set_issuer(cert.get_subject())
-
-        # Subject Alternative Name (SAN) is required by modern browsers
-        alt_names = [b"DNS:localhost", "IP:127.0.0.1".encode(), f"IP:{bind_addr}".encode()]
-        # Remove duplicates
-        alt_names = list(set(alt_names))
-        san_extension = crypto.X509Extension(b"subjectAltName", False, b", ".join(alt_names))
-        cert.add_extensions([san_extension])
-
-        cert.set_pubkey(k)
-        cert.sign(k, "sha256")
+        k = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        subject = x509.Name([
+            x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "Tokyo"),
+            x509.NameAttribute(NameOID.LOCALITY_NAME, "Local"),
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "My App"),
+            x509.NameAttribute(NameOID.COMMON_NAME, bind_addr),
+        ])
+        now = datetime.now(timezone.utc)
+        # Use typed SAN entries; pyOpenSSL removed its X509Extension API.
+        addresses = dict.fromkeys([ipaddress.ip_address("127.0.0.1"),
+                                   ipaddress.ip_address(bind_addr)])
+        alt_names = [x509.DNSName("localhost")]
+        alt_names.extend(x509.IPAddress(address) for address in addresses)
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(subject)
+            .public_key(k.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=10 * 365))
+            .add_extension(x509.SubjectAlternativeName(alt_names), critical=False)
+            .sign(k, hashes.SHA256())
+        )
         with open(cert_file, "wb") as f:
-            f.write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert))
+            f.write(cert.public_bytes(serialization.Encoding.PEM))
         with open(key_file, "wb") as f:
-            f.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, k))
+            f.write(k.private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.TraditionalOpenSSL,
+                serialization.NoEncryption(),
+            ))
         print(f"Generated new self-signed certificate with SAN: {bind_addr}")
 
 

--- a/iw3/player/tests/test_player_cert.py
+++ b/iw3/player/tests/test_player_cert.py
@@ -1,0 +1,45 @@
+"""Test the real generator without importing GPU/server dependencies.
+
+Run: python iw3/player/tests/test_player_cert.py
+Requires cryptography (also a dependency of the existing pyOpenSSL requirement).
+Only the trusted local function is extracted; no network or user code is run.
+"""
+import ast
+import ipaddress
+import os
+from pathlib import Path
+import ssl
+import tempfile
+from datetime import datetime, timezone
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+
+path = Path(__file__).resolve().parents[1] / 'server.py'
+tree = ast.parse(path.read_text(encoding='utf-8'))
+fn = next(n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == 'generate_self_signed_cert')
+namespace = {'os': os, 'ipaddress': ipaddress}
+exec(compile(ast.Module(body=[fn], type_ignores=[]), str(path), 'exec'), namespace)
+generate = namespace['generate_self_signed_cert']
+for address in ('192.0.2.10', '127.0.0.1', '::1'):
+    with tempfile.TemporaryDirectory(prefix='iw3-cert-test-') as temp:
+        directory = Path(temp) / 'certs'
+        cert_path, key_path = directory / 'server.crt', directory / 'server.key'
+        generate(str(directory), str(cert_path), str(key_path), address)
+        cert_bytes, key_bytes = cert_path.read_bytes(), key_path.read_bytes()
+        cert = x509.load_pem_x509_certificate(cert_bytes)
+        key = serialization.load_pem_private_key(key_bytes, password=None)
+        assert cert.public_key().public_numbers() == key.public_key().public_numbers()
+        cert.public_key().verify(cert.signature, cert.tbs_certificate_bytes, padding.PKCS1v15(), cert.signature_hash_algorithm)
+        san = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
+        assert 'localhost' in san.get_values_for_type(x509.DNSName)
+        assert ipaddress.ip_address(address) in san.get_values_for_type(x509.IPAddress)
+        assert ipaddress.ip_address('127.0.0.1') in san.get_values_for_type(x509.IPAddress)
+        assert len(list(san)) == len(set(san))
+        assert cert.not_valid_before_utc <= datetime.now(timezone.utc) < cert.not_valid_after_utc
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.load_cert_chain(cert_path, key_path)
+        generate(str(directory), str(cert_path), str(key_path), address)
+        assert cert_path.read_bytes() == cert_bytes and key_path.read_bytes() == key_bytes
+        print('PASS: certificate signature, key, SANs, TLS loading and preservation for', address)
+print('PASS: all certificate regression tests')


### PR DESCRIPTION
**Written by Hermes–GPT-6 (AI assistant).** Code and automated checks were produced by the assistant; the user separately confirmed that the repaired player starts and works on their Windows host.

## Problem

Generating a new player HTTPS certificate fails with pyOpenSSL 26.4.0:

```text
module 'OpenSSL.crypto' has no attribute 'X509Extension'
```

Reported with environment details in #731. Existing installations with reusable certificates may not encounter this path.

## Change

Use `cryptography.x509.CertificateBuilder` instead of the removed pyOpenSSL extension API. Preserve RSA-2048/SHA256, PEM paths, existing certificate/key reuse, validity duration, and localhost/loopback/bind-IP SANs. Use typed SAN entries and a random certificate serial number. `cryptography` is already a dependency of the existing pyOpenSSL requirement.

## Verification

- `python iw3/player/tests/test_player_cert.py` passes: real signatures, matching keys, IPv4/IPv6 SANs, TLS-context loading and existing-file preservation.
- The test extracts the actual generator to avoid importing unrelated GPU/server dependencies.
- Earlier local integration testing of this same change started the HTTPS server with certificate verification enabled: unauthenticated requests returned 401; authenticated `/` and `/api/list` returned 200.

Targets `dev`. This PR contains only the certificate fix and its regression test—no playback controls, Torch patch, or installer changes.
