### PR TITLE
iw3-player: add compact playback-speed controls for desktop and VR

### DIFF
--- a/iw3/player/package.json
+++ b/iw3/player/package.json
@@ -10,7 +10,7 @@
     "dev": "npm run setup-draco && esbuild src/vendor.js --bundle --outfile=public/lib/vendor.bundle.js --format=esm --sourcemap --define:DEBUG_MODE=true",
     "watch": "esbuild src/vendor.js --bundle --outfile=public/lib/vendor.bundle.js --format=esm --watch --sourcemap --define:DEBUG_MODE=true",
     "lint": "eslint public/js/",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "keywords": [],
   "author": "",

--- a/iw3/player/public/js/menu_main.js
+++ b/iw3/player/public/js/menu_main.js
@@ -24,6 +24,7 @@ class MainMenu {
         this.setupControlRow();
         this.setupSliderRow();
         this.setupTimeRow();
+        this.setupSpeedMenu(defaultFont);
         this.setupFooterRow(); // Status info (FPS, Time, Battery)
     }
 
@@ -33,6 +34,25 @@ class MainMenu {
             width: '100%', paddingLeft: 10, paddingRight: 10, marginTop: 4,
         });
         this.container.add(this.footerRow);
+
+        const u = this.uiManager;
+        const toggleSpeed = (e) => {
+            if (!u.visible) return;
+            e.stopPropagation?.();
+            UIUtils.vibratePointer(e.pointerId, UI_CONFIG.hapticClickIntensity, UI_CONFIG.hapticClickDuration, u);
+            u.switchSubMenu(this.speedMenu);
+        };
+        this.speedReadout = new Container({
+            width: 56, height: 24, borderRadius: 6, cursor: 'pointer',
+            alignItems: 'center', justifyContent: 'center',
+            hover: { backgroundColor: COLORS.hover },
+            onPointerDown: (e) => { if (e.button === 2) toggleSpeed(e); },
+            onClick: (e) => { if (e.button !== 2) toggleSpeed(e); }
+        });
+        this.speedReadoutText = new Text({ text: '1.0x', fontSize: 16, color: COLORS.textDim });
+        this.speedReadout.add(this.speedReadoutText);
+        this.footerRow.add(this.speedReadout);
+        this.footerRow.add(new Container({ flexGrow: 1 }));
 
         const statusGroup = new Container({ flexDirection: 'row', alignItems: 'center', gap: 10, });
         this.footerRow.add(statusGroup);
@@ -166,6 +186,184 @@ class MainMenu {
         volGroup.add(this.volumeSeekBar);
     }
 
+    setupSpeedMenu(defaultFont) {
+        const u = this.uiManager;
+        const popup = new Container({
+            display: 'none', position: 'absolute',
+            marginLeft: UI_CONFIG.menuMarginLeft, marginTop: UI_CONFIG.menuMarginTop,
+            width: 400, padding: 16, gap: 16, flexDirection: 'column',
+            backgroundColor: COLORS.bg, backgroundOpacity: 0.95,
+            borderRadius: 16, borderWidth: 2, borderColor: COLORS.border,
+            fontFamily: defaultFont
+        });
+        this.speedMenu = { container: popup, onClose: () => this.cancelSpeedBoundEdit() };
+        const row = new Container({
+            flexDirection: 'row', alignItems: 'center', justifyContent: 'center',
+            gap: 8, width: '100%', height: 48
+        });
+
+        const button = (text, action, width = 48, label = null) => {
+            const control = new Container({
+                width, height: 48, borderRadius: 12, backgroundColor: COLORS.button,
+                alignItems: 'center', justifyContent: 'center', cursor: 'pointer',
+                hover: { backgroundColor: COLORS.hover }, active: { backgroundColor: COLORS.accent },
+                onPointerEnter: (e) => {
+                    if (u.visible) UIUtils.vibratePointer(e.pointerId, UI_CONFIG.hapticHoverIntensity, UI_CONFIG.hapticHoverDuration, u);
+                },
+                onClick: (e) => {
+                    if (!this.isSpeedMenuActive()) return;
+                    UIUtils.vibratePointer(e.pointerId, UI_CONFIG.hapticClickIntensity, UI_CONFIG.hapticClickDuration, u);
+                    return action();
+                }
+            });
+            control.add(label || new Text({ text, fontSize: 22, color: COLORS.text }));
+            return control;
+        };
+        const header = new Container({ flexDirection: 'row', alignItems: 'center', gap: 8, width: '100%' });
+        this.speedValueText = new Text({ text: 'Speed 1.0x', fontSize: 20, color: COLORS.text });
+        header.add(this.speedValueText);
+        header.add(new Container({ flexGrow: 1 }));
+        this.speedDefaults = button('', () => {
+            this.cancelSpeedBoundEdit();
+            return u.restorePlaybackSpeedDefaults();
+        }, 48, new Image({ src: 'icons/restore.svg', width: 22, height: 22, color: COLORS.text }));
+        header.add(this.speedDefaults);
+        this.speedReset = button('1x', () => u.resetPlaybackSpeed(), 48);
+        header.add(this.speedReset);
+        this.speedClose = button('X', () => u.switchSubMenu(null), 40);
+        header.add(this.speedClose);
+        popup.add(header);
+        popup.add(row);
+        const step = (direction) => {
+            u.playbackSpeed.step(direction);
+            return u.setPlaybackSpeed(u.playbackSpeed.rate);
+        };
+        this.speedMinus = button('-', () => step(-1));
+        row.add(this.speedMinus);
+        this.speedTrack = new Container({
+            width: 240, height: 16, flexDirection: 'row', alignItems: 'center',
+            backgroundColor: COLORS.track, borderRadius: 8, cursor: 'pointer', overflow: 'visible',
+            onPointerDown: (e) => {
+                if (u.visible) UIUtils.vibratePointer(e.pointerId, UI_CONFIG.hapticHoverIntensity, UI_CONFIG.hapticHoverDuration, u);
+            },
+            onClick: (e) => {
+                if (!this.isSpeedMenuActive()) return;
+                UIUtils.vibratePointer(e.pointerId, UI_CONFIG.hapticClickIntensity, UI_CONFIG.hapticClickDuration, u);
+                u.handlePlaybackSpeed(e, this.speedTrack, true);
+            },
+            onPointerMove: (e) => { if (this.isSpeedMenuActive() && e.buttons > 0) u.handlePlaybackSpeed(e, this.speedTrack, false); },
+            onPointerUp: () => { if (this.isSpeedMenuActive()) u.saveSettings(); },
+            onPointerLeave: (e) => { if (this.isSpeedMenuActive() && e.buttons > 0) u.saveSettings(); }
+        });
+        this.speedThumb = new Container({ width: 24, height: 24, backgroundColor: COLORS.thumb, borderRadius: 12, borderWidth: 1.5, borderColor: 0xffffff });
+        this.speedTrack.add(this.speedThumb);
+        row.add(this.speedTrack);
+        this.speedPlus = button('+', () => step(1));
+        row.add(this.speedPlus);
+
+        const boundsRow = new Container({ flexDirection: 'row', gap: 8, width: '100%' });
+        popup.add(boundsRow);
+        this.speedBoundFields = {};
+        this.speedBoundTexts = {};
+        for (const bound of ['min', 'max']) {
+            const group = new Container({ flexDirection: 'column', gap: 4, width: 172 });
+            group.add(new Text({ text: bound === 'min' ? 'Min' : 'Max', fontSize: 16, color: COLORS.textDim }));
+            const label = new Text({ text: String(u.playbackSpeed[bound]), fontSize: 20, color: COLORS.text });
+            this.speedBoundTexts[bound] = label;
+            this.speedBoundFields[bound] = button('', () => this.editSpeedBound(bound), 172, label);
+            group.add(this.speedBoundFields[bound]);
+            boundsRow.add(group);
+        }
+
+        this.speedKeypad = new Container({ display: 'none', flexDirection: 'column', gap: 8, width: '100%' });
+        popup.add(this.speedKeypad);
+        this.speedInputText = new Text({ text: '', fontSize: 20, color: COLORS.text, width: '100%' });
+        this.speedKeypad.add(this.speedInputText);
+        this.speedKeyButtons = {};
+        for (const keys of [['7', '8', '9', 'Back'], ['4', '5', '6', 'Clear'], ['1', '2', '3', 'Cancel'], ['0', '.', 'OK']]) {
+            const keyRow = new Container({ flexDirection: 'row', gap: 8, width: '100%' });
+            this.speedKeypad.add(keyRow);
+            for (const key of keys) {
+                const keyButton = button(key, () => this.handleSpeedKey(key), key === 'OK' ? 172 : 82);
+                this.speedKeyButtons[key] = keyButton;
+                keyRow.add(keyButton);
+            }
+        }
+        if (typeof window !== 'undefined') {
+            // Capture before InputManager's bubbling shortcut listeners, including in XR.
+            const options = { capture: true, signal: u.abortController?.signal };
+            for (const type of ['keydown', 'keyup']) {
+                window.addEventListener(type, (e) => this.handleSpeedKeyboard(e), options);
+            }
+        }
+    }
+
+    handleSpeedKeyboard(e) {
+        if (!this.isSpeedMenuActive() || !this.speedBoundEdit) return;
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        if (e.type !== 'keydown') return;
+        if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'a') {
+            this.speedBoundEdit.replace = true;
+            return;
+        }
+        if (e.ctrlKey || e.metaKey || e.altKey) return;
+        const key = { Enter: 'OK', Escape: 'Cancel', Backspace: 'Back', Delete: 'Clear' }[e.key] || e.key;
+        return this.handleSpeedKey(key);
+    }
+
+    isSpeedMenuActive() {
+        return this.uiManager.visible && this.uiManager.activeSubMenu === this.speedMenu;
+    }
+
+    editSpeedBound(bound) {
+        if (!this.isSpeedMenuActive()) return;
+        const applied = this.uiManager.setPlaybackSpeed(this.uiManager.playbackSpeed[bound]);
+        this.speedBoundEdit = { bound, text: String(this.uiManager.playbackSpeed[bound]), replace: true };
+        this.speedKeypad.setProperties({ display: 'flex' });
+        this.updateSpeedInputText();
+        return applied;
+    }
+
+    updateSpeedInputText() {
+        const edit = this.speedBoundEdit;
+        this.speedInputText.setProperties({ text: `${edit.bound === 'min' ? 'Min' : 'Max'}: ${edit.text || '_'}` });
+    }
+
+    cancelSpeedBoundEdit() {
+        this.speedBoundEdit = null;
+        this.speedKeypad.setProperties({ display: 'none' });
+    }
+
+    async handleSpeedKey(key) {
+        if (!this.isSpeedMenuActive() || !this.speedBoundEdit) return;
+        const edit = this.speedBoundEdit;
+        if (key === 'Cancel') {
+            this.cancelSpeedBoundEdit();
+            return;
+        }
+        if (key === 'OK') {
+            const value = /^(?:\d+(?:\.\d*)?|\.\d+)$/.test(edit.text) ? Number(edit.text) : NaN;
+            const speed = this.uiManager.playbackSpeed;
+            if (await this.uiManager.setPlaybackSpeedBounds(edit.bound === 'min' ? value : speed.min,
+                edit.bound === 'max' ? value : speed.max)) {
+                if (this.speedBoundEdit === edit) this.cancelSpeedBoundEdit();
+                this.sync({});
+            } else {
+                this.uiManager.showNotification('Use 0.01 to 100; Min < Max');
+            }
+            return;
+        }
+        if (key === 'Clear') edit.text = '';
+        else if (key === 'Back') edit.text = edit.text.slice(0, -1);
+        else if (/^[0-9.]$/.test(key)) {
+            if (edit.replace) edit.text = '';
+            if (key !== '.' || !edit.text.includes('.')) edit.text += key;
+        } else return;
+        edit.replace = false;
+        this.updateSpeedInputText();
+    }
+
     setupTimeRow() {
         this.timeRow = new Container({
             flexDirection: 'row',
@@ -206,6 +404,19 @@ class MainMenu {
     }
 
     sync(params) {
+        const speed = this.uiManager.playbackSpeed;
+        const speedKey = `${speed.rate}/${speed.min}/${speed.max}`;
+        if (this._lastSpeedKey !== speedKey) {
+            const displayRate = Number(speed.rate.toPrecision(4));
+            const rateText = Number.isInteger(displayRate) ? displayRate.toFixed(1) : String(displayRate);
+            this.speedValueText.setProperties({ text: `Speed ${rateText}x` });
+            this.speedReadoutText.setProperties({ text: `${rateText}x` });
+            this.speedBoundTexts.min.setProperties({ text: String(speed.min) });
+            this.speedBoundTexts.max.setProperties({ text: String(speed.max) });
+            const percent = Math.max(0, Math.min(1, (speed.rate - speed.min) / (speed.max - speed.min)));
+            this.speedThumb.setProperties({ marginLeft: percent * (240 - 24) });
+            this._lastSpeedKey = speedKey;
+        }
         if (params.slowMetricsUpdated) {
             const now = new Date();
             const timeStr = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;

--- a/iw3/player/public/js/playback_speed.js
+++ b/iw3/player/public/js/playback_speed.js
@@ -1,0 +1,70 @@
+// Shared playback state: deliberately independent of file-specific settings.
+export class PlaybackSpeed {
+    // Configurable UI bounds, not a promise of browser/codec support.
+    static MIN = 0.01;
+    static MAX = 100;
+
+    constructor(saved = {}) {
+        this.min = 0.1;
+        this.max = 16;
+        this.rate = 1;
+        const legacyDefaults = (saved?.min === 0.5 && saved?.max === 2) ||
+            (saved?.min === 0.25 && saved?.max === 16);
+        if (!(legacyDefaults && !saved?.customBounds)) {
+            this.setBounds(saved?.min, saved?.max);
+        }
+        this.setRate(saved?.rate);
+    }
+
+    setBounds(min, max) {
+        if (!Number.isFinite(min) || !Number.isFinite(max) ||
+            min < PlaybackSpeed.MIN || max > PlaybackSpeed.MAX ||
+            min >= max) return false;
+        this.min = min;
+        this.max = max;
+        this.setRate(this.rate);
+        return true;
+    }
+
+    setRate(rate) {
+        if (!Number.isFinite(rate)) return;
+        this.rate = Math.max(this.min, Math.min(this.max, rate));
+    }
+
+    step(direction) {
+        this.setRate(Number((this.rate * Math.pow(1.1, direction)).toPrecision(15)));
+    }
+
+    applyTo(video) {
+        if (!video) return true;
+        const previousRate = video.playbackRate;
+        const previousDefault = video.defaultPlaybackRate;
+        try {
+            video.playbackRate = this.rate;
+            video.defaultPlaybackRate = this.rate;
+            for (const key of ['preservesPitch', 'mozPreservesPitch', 'webkitPreservesPitch']) {
+                if (key in video) video[key] = true;
+            }
+            this.rate = video.playbackRate;
+            return true;
+        } catch (_error) {
+            // A rejected assignment must not turn into a clamped retry loop.
+            // The actual rate may remain outside the user's configured bounds.
+            try {
+                if (video.playbackRate !== previousRate) video.playbackRate = previousRate;
+                if (video.defaultPlaybackRate !== previousDefault) video.defaultPlaybackRate = previousDefault;
+            } catch (_restoreError) { /* Read back actual state even if restoration fails. */ }
+            if (Number.isFinite(video.playbackRate)) this.rate = video.playbackRate;
+            return false;
+        }
+    }
+
+    toJSON() {
+        const saved = { min: this.min, max: this.max, rate: this.rate };
+        // Distinguish an intentional new choice from the legacy default pair.
+        if ((this.min === 0.5 && this.max === 2) || (this.min === 0.25 && this.max === 16)) {
+            saved.customBounds = true;
+        }
+        return saved;
+    }
+}

--- a/iw3/player/public/js/stereo_player.js
+++ b/iw3/player/public/js/stereo_player.js
@@ -163,6 +163,7 @@ class StereoPlayer extends THREE.Group {
                 this.videoElement.autoplay = true;
                 this.videoElement.loop = this.uiManager.videoRepeat;
                 this.videoElement.volume = this.uiManager.currentVolume;
+                this.uiManager.applyPlaybackSpeed();
 
                 this.videoElement.onended = () => {
                     this.uiManager.updateFileConfig(file, { playback_time: 0 });
@@ -176,6 +177,8 @@ class StereoPlayer extends THREE.Group {
 
             const handleMetadata = () => {
                 if (this.currentLoadId !== loadId) { if (!forcedFormat) { this.videoElement.pause(); this.videoElement.src = ""; } return; }
+                // Source loads and format/mipmap changes may reset media properties.
+                this.uiManager.applyPlaybackSpeed();
                 const vw = this.videoElement.videoWidth;
                 const vh = this.videoElement.videoHeight;
                 

--- a/iw3/player/public/js/ui_manager.js
+++ b/iw3/player/public/js/ui_manager.js
@@ -4,6 +4,7 @@ import { Container, Text, reversePainterSortStable } from '@pmndrs/uikit';
 import { forwardHtmlEvents, createRayPointer } from '@pmndrs/pointer-events';
 import { LIMITS, DEFAULTS, UI_CONFIG, COLORS, FONT_CONFIG, SETTINGS_METADATA } from './constants.js';
 import { storage } from './storage.js';
+import { PlaybackSpeed } from './playback_speed.js';
 import { UIUtils } from './ui_common.js';
 
 // Import split UI components
@@ -39,6 +40,7 @@ class UIManager extends THREE.Group {
         
         // Helpers
         this.currentVolume = DEFAULTS.screen_volume;
+        this.playbackSpeed = new PlaybackSpeed();
         this.subY = DEFAULTS.subtitle_y;
         this.subZ = DEFAULTS.subtitle_z;
         this.subFontSize = DEFAULTS.subtitle_font_size;
@@ -144,7 +146,7 @@ class UIManager extends THREE.Group {
     updateMenuPositions() {
         const offset = this.menuAlignment === 'right' ? UI_CONFIG.menuMarginLeft : -UI_CONFIG.menuMarginLeft;
         // Apply to all settings menus except explorer and main menu
-        const targetMenus = [this.screenSettings, this.colorSettings, this.environmentSettings, this.renderSettings, this.subtitleSettings];
+        const targetMenus = [this.screenSettings, this.colorSettings, this.environmentSettings, this.renderSettings, this.subtitleSettings, this.speedMenu];
         targetMenus.forEach(menu => {
             if (menu && menu.container) {
                 menu.container.setProperties({ marginLeft: offset });
@@ -220,6 +222,7 @@ class UIManager extends THREE.Group {
         this.add(this.mainContainer);
 
         this.mainMenu = new MainMenu(this, defaultFont);
+        this.speedMenu = this.mainMenu.speedMenu;
         this.screenSettings = new ScreenSettingsMenu(this, defaultFont);
         this.colorSettings = new ColorSettingsMenu(this, defaultFont);
         this.environmentSettings = new EnvironmentSettingsMenu(this, defaultFont);
@@ -230,6 +233,7 @@ class UIManager extends THREE.Group {
         this.allSettingsMenus = [this.screenSettings, this.colorSettings, this.environmentSettings, this.renderSettings, this.subtitleSettings];
 
         this.mainContainer.add(this.mainMenu.container);
+        this.mainContainer.add(this.speedMenu.container);
         this.mainContainer.add(this.screenSettings.container);
         this.mainContainer.add(this.colorSettings.container);
         this.mainContainer.add(this.environmentSettings.container);
@@ -315,6 +319,7 @@ class UIManager extends THREE.Group {
     }
 
     switchSubMenu(targetMenu) {
+        this.activeSubMenu?.onClose?.();
         if (this.activeSubMenu === targetMenu) {
             if (this.activeSubMenu) { this.activeSubMenu.container.setProperties({ display: 'none' }); this.activeSubMenu = null; }
             return;
@@ -749,6 +754,46 @@ class UIManager extends THREE.Group {
         this.onSliderChange('screen_volume', percent, shouldSave);
     }
 
+    applyPlaybackSpeed() {
+        if (!this.playbackSpeed.applyTo(this.stereoPlayer.videoElement)) {
+            this.showNotification(`Speed unsupported; kept ${this.playbackSpeed.rate}x`);
+        }
+    }
+
+    async setPlaybackSpeed(rate, shouldSave = true) {
+        this.playbackSpeed.setRate(rate);
+        this.applyPlaybackSpeed();
+        this.syncUI();
+        if (shouldSave) await storage.set('playback_speed', this.playbackSpeed.toJSON());
+    }
+
+    async setPlaybackSpeedBounds(min, max) {
+        if (!this.playbackSpeed.setBounds(min, max)) return false;
+        await this.setPlaybackSpeed(this.playbackSpeed.rate);
+        return true;
+    }
+
+    resetPlaybackSpeed() {
+        const speed = this.playbackSpeed;
+        speed.setBounds(Math.min(speed.min, 1), Math.max(speed.max, 1));
+        return this.setPlaybackSpeed(1);
+    }
+
+    restorePlaybackSpeedDefaults() {
+        this.playbackSpeed = new PlaybackSpeed();
+        return this.setPlaybackSpeed(1);
+    }
+
+    handlePlaybackSpeed(e, track, shouldSave = true) {
+        if (!this.visible || !e.point) return;
+        const local = track.worldToLocal(e.point.clone());
+        const percent = THREE.MathUtils.clamp(0.5 + local.x, 0, 1);
+        const speed = this.playbackSpeed;
+        const rate = percent === 0 ? speed.min : percent === 1 ? speed.max :
+            Math.round((speed.min + (speed.max - speed.min) * percent) * 100) / 100;
+        return this.setPlaybackSpeed(rate, shouldSave);
+    }
+
     async onSliderChange(id, val, shouldSave = true) {
         // Capture the applying state synchronously to avoid race conditions after await
         const wasApplyingDuringCall = this.isApplyingConfig;
@@ -813,6 +858,8 @@ class UIManager extends THREE.Group {
     // --- Sync & Storage ---
 
     async loadSettings() { 
+        this.playbackSpeed = new PlaybackSpeed(storage.get('playback_speed'));
+        this.applyPlaybackSpeed();
         await this.screenSettings.load();
         await this.colorSettings.load();
         await this.environmentSettings.load();
@@ -826,6 +873,7 @@ class UIManager extends THREE.Group {
     
     async saveSettings() { 
         await Promise.all([
+            storage.set('playback_speed', this.playbackSpeed.toJSON()),
             this.screenSettings.save(),
             this.colorSettings.save(),
             this.environmentSettings.save(),

--- a/iw3/player/tests/compact-speed.test.mjs
+++ b/iw3/player/tests/compact-speed.test.mjs
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {fixture,event,load} from './ui-fixture.mjs';
+
+test('compact speed readout opens a separate hidden popup on right click or VR click',async()=>{
+    const {u,UIUtils}=await fixture();
+    const MainMenu=await load('menu_main','MainMenu',{UIUtils});
+    const menu=new MainMenu(u,'NotoSans');
+    assert.ok(menu.speedReadout,'compact readout replaces full-width speed row');
+    assert.equal(menu.speedReadoutText.props.text,'1.0x');
+    assert.equal(menu.speedMenu.container.props.display,'none');
+    assert.ok(!menu.container.children.includes(menu.speedMenu.container),'popup is not an extra main-menu row');
+    const right={...event(),button:2,stopPropagation(){}};
+    menu.speedReadout.props.onPointerDown(right);
+    assert.equal(u.activeSubMenu,menu.speedMenu);
+    assert.equal(menu.speedMenu.container.props.display,'flex');
+    menu.speedReadout.props.onClick(right);
+    assert.equal(u.activeSubMenu,menu.speedMenu,'right click must not toggle twice');
+    menu.speedClose.props.onClick(event());
+    assert.equal(u.activeSubMenu,null);
+    menu.speedReadout.props.onClick({...event(),button:0});
+    assert.equal(u.activeSubMenu,menu.speedMenu);
+    await u.setPlaybackSpeed(1.8);menu.sync({});
+    assert.equal(menu.speedReadoutText.props.text,'1.8x');
+    u.visible=false;
+    menu.speedReadout.props.onPointerDown(right);
+    assert.equal(u.activeSubMenu,menu.speedMenu,'hidden readout ignores input');
+});

--- a/iw3/player/tests/media-speed.test.mjs
+++ b/iw3/player/tests/media-speed.test.mjs
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { fixture, load } from './ui-fixture.mjs';
+
+test('loadMedia applies selected rate to new videos, metadata reloads and forced-format reuse', async () => {
+    const { u, storage } = await fixture();
+    const made = [];
+    const document = { createElement() {
+        const video = { playbackRate: 1, defaultPlaybackRate: 1, preservesPitch: false, videoWidth: 1920, videoHeight: 1080,
+            pause() {}, load() {}, currentTime: 0 };
+        made.push(video);
+        return video;
+    } };
+    const THREE = { Group: class {}, VideoTexture: class {}, SRGBColorSpace: 'srgb' };
+    const StereoPlayer = await load('stereo_player', 'StereoPlayer', { document, THREE, storage });
+    const p = Object.create(StereoPlayer.prototype);
+    const files = [{ type: 'video', name: 'one.mp4', path: '/one.mp4' }, { type: 'video', name: 'two.mp4', path: '/two.mp4' }, { type: 'image', name: 'still.jpg', path: '/still.jpg' }];
+    Object.assign(p, { uiManager: u, currentLoadId: 0,
+        galleryManager: { playbackGallery: files, setPlayingItem() {}, getCurrentItem: () => null },
+        stereoScreen: { displayScreenLeft: { material: {} }, displayScreenRight: { material: {} }, updateTexture() {} },
+        debugLogInstance: { log() {} }, renderer: { capabilities: { getMaxAnisotropy: () => 1 } },
+        loadSubtitles() {}, textureCache: new Map([['/still.jpg', { texture: {}, aspectRatio: 1 }]]), prefetchImages() {} });
+    u.stereoPlayer = p;
+    Object.assign(u, { updateSubtitleText() {}, getFileConfig: async () => null, updateFileConfig() {}, hideRecentButton() {} });
+    u.renderSettings.values = {};
+    await u.setPlaybackSpeed(1.8);
+    await p.loadMedia(0);
+    assert.equal(p.videoElement.playbackRate, 1.8);
+    assert.equal(p.videoElement.preservesPitch, true);
+    p.videoElement.playbackRate = 1;
+    p.videoElement.onloadedmetadata();
+    assert.equal(p.videoElement.playbackRate, 1.8);
+    await p.loadMedia(1);
+    assert.equal(made.length, 2);
+    assert.equal(p.videoElement.playbackRate, 1.8);
+    await p.loadMedia(1, 'sbs');
+    assert.equal(made.length, 2);
+    assert.equal(p.videoElement.playbackRate, 1.8);
+    await p.loadMedia(2);
+    assert.equal(p.videoElement, null);
+    assert.equal(u.playbackSpeed.rate, 1.8);
+    await p.loadMedia(0);
+    assert.equal(p.videoElement.playbackRate, 1.8);
+});

--- a/iw3/player/tests/playback-speed.test.mjs
+++ b/iw3/player/tests/playback-speed.test.mjs
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { PlaybackSpeed } from '../public/js/playback_speed.js';
+
+test('bounds accept exact finite decimals from .01 to 100 without requiring 1x', () => {
+    const speed = new PlaybackSpeed();
+    assert.deepEqual(speed.toJSON(), { min: 0.1, max: 16, rate: 1 });
+    for (const [min, max] of [[0, 2], [-1, 2], [NaN, 2], [.5, Infinity], [2, .5], [1, 1], [.009, 2], [.5, 101], ['.5', 2]]) {
+        assert.equal(speed.setBounds(min, max), false);
+        assert.deepEqual(speed.toJSON(), { min: .1, max: 16, rate: 1 });
+    }
+    for (const [min, max] of [[.01, 100], [.0625, .99], [2.12345, 32]]) {
+        assert.equal(speed.setBounds(min, max), true);
+        assert.equal(speed.min, min);
+        assert.equal(speed.max, max);
+        assert.ok(speed.rate >= min && speed.rate <= max);
+        assert.deepEqual(new PlaybackSpeed(speed.toJSON()).toJSON(), speed.toJSON());
+    }
+    assert.deepEqual(new PlaybackSpeed(null).toJSON(), { min: .1, max: 16, rate: 1 });
+    assert.deepEqual(new PlaybackSpeed({min: .5, max: 2, rate: 1.7}).toJSON(), {min: .1, max: 16, rate: 1.7});
+    assert.deepEqual(new PlaybackSpeed({min: .5, max: 3, rate: 1.7}).toJSON(), {min: .5, max: 3, rate: 1.7});
+});
+
+test('deliberately choosing the old default pair survives a save/reload', () => {
+    const speed = new PlaybackSpeed();
+    speed.setBounds(0.5, 2);
+    const restored = new PlaybackSpeed(speed.toJSON());
+    assert.equal(restored.min, 0.5);
+    assert.equal(restored.max, 2);
+});
+
+test('rate retains precision, clamps, and steps proportionally without decimal drift', () => {
+    const speed = new PlaybackSpeed();
+    speed.setRate(1.26);
+    assert.equal(speed.rate, 1.26);
+    speed.step(-1);
+    assert.ok(Math.abs(speed.rate - 1.26 / 1.1) < 1e-12);
+    speed.setRate(99);
+    assert.equal(speed.rate, 16);
+    speed.setRate(-5);
+    assert.equal(speed.rate, .1);
+    speed.setRate(NaN);
+    assert.equal(speed.rate, .1);
+    speed.setBounds(.01, 100);
+    speed.setRate(.0625);
+    assert.equal(speed.rate, .0625);
+    speed.step(-1);
+    assert.ok(Math.abs(speed.rate - .0625 / 1.1) < 1e-12);
+    speed.step(1);
+    assert.ok(Math.abs(speed.rate - .0625) < 1e-12);
+});
+
+test('applies rate and pitch preservation without playing or seeking', () => {
+    const speed = new PlaybackSpeed({ rate: 1.7 });
+    assert.equal(speed.applyTo(null), true);
+    for (const pitchKey of ['preservesPitch', 'mozPreservesPitch', 'webkitPreservesPitch']) {
+        const video = { playbackRate: 1, defaultPlaybackRate: 1, [pitchKey]: false, paused: true, currentTime: 23 };
+        assert.equal(speed.applyTo(video), true);
+        assert.equal(video.playbackRate, 1.7);
+        assert.equal(video.defaultPlaybackRate, 1.7);
+        assert.equal(video[pitchKey], true);
+        assert.equal(video.paused, true);
+        assert.equal(video.currentTime, 23);
+    }
+});

--- a/iw3/player/tests/speed-keypad.test.mjs
+++ b/iw3/player/tests/speed-keypad.test.mjs
@@ -1,0 +1,138 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {fixture, event, load} from './ui-fixture.mjs';
+
+async function setup(extra = {}) {
+    const f = await fixture();
+    f.u.abortController = new AbortController();
+    const MainMenu = await load('menu_main', 'MainMenu', {UIUtils: f.UIUtils, ...extra});
+    const menu = new MainMenu(f.u, 'NotoSans');
+    f.u.mainMenu = menu;
+    f.u.speedMenu = menu.speedMenu;
+    menu.speedReadout.props.onClick(event());
+    return {...f, menu};
+}
+const press = (menu, key) => menu.speedKeyButtons[key].props.onClick(event());
+async function enter(menu, bound, text) {
+    menu.speedBoundFields[bound].props.onClick(event());
+    await press(menu, 'Clear');
+    for (const key of text) await press(menu, key);
+    await press(menu, 'OK');
+}
+
+test('popup min/max fields use an in-world keypad, apply exact bounds live and persist', async () => {
+    const {u, menu, cache} = await setup();
+    assert.ok(menu.speedBoundFields?.min, 'popup has clickable Min');
+    assert.ok(menu.speedBoundFields.max, 'popup has clickable Max');
+    assert.equal(menu.speedKeypad.props.display, 'none');
+    assert.ok(menu.speedMenu.container.children.includes(menu.speedKeypad));
+    assert.deepEqual(Object.keys(menu.speedKeyButtons).sort(), [...'0123456789', '.', 'Back', 'Clear', 'Cancel', 'OK'].sort());
+    menu.sync({});
+    assert.equal(menu.speedBoundTexts.min.props.text, '0.1');
+    assert.equal(menu.speedBoundTexts.max.props.text, '16');
+    await enter(menu, 'min', '.0625');
+    assert.equal(u.playbackSpeed.min, .0625);
+    assert.equal(cache.playback_speed.min, .0625);
+    assert.equal(menu.speedKeypad.props.display, 'none');
+    await enter(menu, 'max', '100');
+    assert.equal(cache.playback_speed.max, 100);
+    await u.setPlaybackSpeed(.0625);
+    menu.sync({});
+    assert.equal(menu.speedReadoutText.props.text, '0.0625x');
+    assert.equal(menu.speedBoundTexts.min.props.text, '0.0625');
+    await enter(menu, 'min', '.01');
+    await u.setPlaybackSpeed(.01);
+    menu.sync({});
+    assert.equal(menu.speedReadoutText.props.text, '0.01x');
+    menu.speedPlus.props.onClick(event());
+    assert.equal(u.playbackSpeed.rate, .011);
+    menu.speedMinus.props.onClick(event());
+    assert.equal(u.playbackSpeed.rate, .01);
+});
+
+test('keypad rejects invalid bounds, edits decimal/backspace, cancels and ignores hidden controls', async () => {
+    const {u, menu, cache} = await setup();
+    assert.ok(menu.speedBoundFields?.min);
+    for (const text of ['', '.', '0', '.009', '16', '100', '101']) {
+        await enter(menu, 'min', text);
+        assert.equal(u.playbackSpeed.min, .1, text);
+        assert.equal(menu.speedKeypad.props.display, 'flex', 'invalid draft stays editable');
+        assert.equal(cache.playback_speed.min, .1, 'tap saves selected bound but invalid draft does not change bounds');
+        assert.match(u.notification, /0.01.*100|min.*max/i);
+        await press(menu, 'Cancel');
+    }
+    menu.speedBoundFields.min.props.onClick(event());
+    await press(menu, 'Clear');
+    for (const key of ['.', '0', '2', '.', '5', 'Back', '6', 'OK']) await press(menu, key);
+    assert.equal(u.playbackSpeed.min, .026);
+    menu.speedBoundFields.max.props.onClick(event());
+    await press(menu, '3');
+    await press(menu, 'Cancel');
+    assert.equal(u.playbackSpeed.max, 16);
+    menu.speedBoundFields.max.props.onClick(event());
+    const beforeHide = u.playbackSpeed.rate;
+    menu.speedClose.props.onClick(event());
+    assert.equal(menu.speedKeypad.props.display, 'none');
+    menu.speedPlus.props.onClick(event());
+    menu.speedBoundFields.min.props.onClick(event());
+    assert.equal(u.playbackSpeed.rate, beforeHide);
+    assert.equal(menu.speedKeypad.props.display, 'none');
+    menu.speedReadout.props.onClick(event());
+    menu.speedBoundFields.max.props.onClick(event());
+    u.switchSubMenu({container: menu.container});
+    assert.equal(menu.speedKeypad.props.display, 'none');
+});
+
+test('physical keyboard edits only active popup, captures shortcuts and cleans up on abort', async () => {
+    const registrations = [];
+    const window = new class extends EventTarget {
+        addEventListener(type, listener, options) {
+            registrations.push({type, options});
+            super.addEventListener(type, listener, options);
+        }
+    }();
+    const {u, menu, cache} = await setup({window});
+    assert.equal(registrations.length, 2, 'keydown/keyup capture listeners are installed');
+    for (const {options} of registrations) {
+        assert.equal(options.capture, true);
+        assert.equal(options.signal, u.abortController.signal);
+    }
+    let shortcutCalls = 0;
+    window.addEventListener('keydown', () => shortcutCalls++);
+    const send = (key, type = 'keydown', extra = {}) => {
+        const e = new Event(type, {cancelable: true});
+        Object.assign(e, {key, ...extra});
+        window.dispatchEvent(e);
+        return e.defaultPrevented;
+    };
+    assert.equal(send(' '), false, 'visible popup without active field leaves shortcuts alone');
+    menu.speedBoundFields.max.props.onClick(event());
+    for (const key of [' ', 'ArrowLeft', 'q', 'Shift', 'Tab']) {
+        assert.equal(send(key), true);
+        assert.equal(send(key, 'keyup'), true);
+    }
+    assert.equal(shortcutCalls, 1);
+    send('3'); send('2'); send('Enter');
+    await new Promise(setImmediate);
+    assert.equal(cache.playback_speed.max, 32);
+    assert.equal(menu.speedKeypad.props.display, 'none');
+    menu.speedBoundFields.min.props.onClick(event());
+    send('a', 'keydown', {ctrlKey: true});
+    for (const key of ['.', '0', '6', '2', '6', 'Backspace', '5', 'Enter']) send(key);
+    await new Promise(setImmediate);
+    assert.equal(cache.playback_speed.min, .0625);
+    menu.speedBoundFields.min.props.onClick(event());
+    send('Delete'); send('0'); send('Escape');
+    assert.equal(menu.speedKeypad.props.display, 'none');
+    assert.equal(u.playbackSpeed.min, .0625);
+    menu.speedBoundFields.min.props.onClick(event());
+    u.visible = false;
+    assert.equal(send('1'), false);
+    u.visible = true;
+    u.switchSubMenu(null);
+    assert.equal(send('1'), false);
+    menu.speedReadout.props.onClick(event());
+    menu.speedBoundFields.min.props.onClick(event());
+    u.abortController.abort();
+    assert.equal(send('1'), false, 'abort removed the capture listener');
+});

--- a/iw3/player/tests/speed-refinements.test.mjs
+++ b/iw3/player/tests/speed-refinements.test.mjs
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {PlaybackSpeed} from '../public/js/playback_speed.js';
+import {fixture,event,load} from './ui-fixture.mjs';
+
+test('Quest defaults, proportional steps, and intentional previous defaults persist',()=>{
+    const speed=new PlaybackSpeed();
+    assert.equal(speed.min,0.1);assert.equal(speed.max,16);
+    assert.equal(new PlaybackSpeed({min:.25,max:16,rate:1}).min,.1);
+    speed.setBounds(.25,16);
+    assert.equal(new PlaybackSpeed(speed.toJSON()).min,.25);
+    for (const rate of [.25,1,8]) {
+        speed.setRate(rate);speed.step(1);
+        assert.ok(Math.abs(speed.rate-rate*1.1)<1e-12);
+        speed.step(-1);assert.ok(Math.abs(speed.rate-rate)<1e-12);
+    }
+    speed.setRate(16);speed.step(1);assert.equal(speed.rate,16);
+});
+
+test('popup defaults reset restores whole speed config and bound taps apply immediately',async()=>{
+    const {u,UIUtils,cache}=await fixture();
+    const MainMenu=await load('menu_main','MainMenu',{UIUtils});
+    const menu=new MainMenu(u,'NotoSans');u.mainMenu=menu;u.speedMenu=menu.speedMenu;
+    menu.speedReadout.props.onClick(event());
+    assert.ok(menu.speedDefaults,'restore defaults control exists');
+    await menu.speedBoundFields.min.props.onClick(event());
+    assert.equal(u.stereoPlayer.videoElement.playbackRate,.1);
+    await menu.speedBoundFields.max.props.onClick(event());
+    assert.equal(u.stereoPlayer.videoElement.playbackRate,16);
+    await u.setPlaybackSpeedBounds(.5,3);await u.setPlaybackSpeed(2);
+    await menu.speedDefaults.props.onClick(event());
+    assert.equal(u.playbackSpeed.min,.1);assert.equal(u.playbackSpeed.max,16);
+    assert.equal(u.stereoPlayer.videoElement.playbackRate,1);
+    assert.equal(cache.playback_speed.min,.1);assert.equal(cache.playback_speed.max,16);
+    assert.equal(menu.speedKeypad.props.display,'none');
+});

--- a/iw3/player/tests/ui-fixture.mjs
+++ b/iw3/player/tests/ui-fixture.mjs
@@ -1,0 +1,34 @@
+import { readFile } from 'node:fs/promises';
+import * as constants from '../public/js/constants.js';
+import { PlaybackSpeed } from '../public/js/playback_speed.js';
+
+// Only GPU, DOM and IndexedDB boundaries are doubled. Real menu/helper/manager
+// bodies are executed; no replacement implementations of playback behavior.
+export class Widget {
+    constructor(props = {}) { this.props = props; this.children = []; }
+    add(child) { this.children.push(child); return this; }
+    setProperties(props) { Object.assign(this.props, props); }
+    worldToLocal(point) { return point; }
+}
+export async function load(name, symbol, extra = {}) {
+    const source = (await readFile(new URL(`../public/js/${name}.js`, import.meta.url), 'utf8'))
+        .replace(/^import .*;\r?\n/gm, '')
+        .replace(/^export \{.*\};?\r?$/gm, '').replace(/^export const /gm, 'const ');
+    const deps = { ...constants, PlaybackSpeed, Container: Widget, Text: Widget, Image: Widget,
+        THREE: { Group: class {}, MathUtils: { clamp: (x, min, max) => Math.max(min, Math.min(max, x)) } }, ...extra };
+    return new Function(...Object.keys(deps), `${source}\nreturn ${symbol};`)(...Object.values(deps));
+}
+export async function fixture() {
+    const cache = {};
+    const storage = { get: (k, d = null) => cache[k] ?? d, set: async (k, v) => { cache[k] = structuredClone(v); } };
+    const UIUtils = await load('ui_common', 'UIUtils');
+    const UIManager = await load('ui_manager', 'UIManager', { UIUtils, storage });
+    const u = Object.create(UIManager.prototype);
+    Object.assign(u, { playbackSpeed: new PlaybackSpeed(), visible: true, xrPointers: [], _atLimit: {},
+        stereoPlayer: { videoElement: { playbackRate: 1, defaultPlaybackRate: 1, preservesPitch: false }, galleryManager: { getCurrentItem: () => null }, stereoScreen: {} },
+        syncUI() {}, showNotification(message) { this.notification = message; }, dirtyGroups: new Set(),
+        allSettingsMenus: [], menuAlignment: 'right', videoRepeat: false });
+    for (const k of ['screenSettings', 'colorSettings', 'environmentSettings', 'renderSettings', 'subtitleSettings']) u[k] = { load() {}, save() {} };
+    return { u, cache, storage, UIUtils };
+}
+export const event = (x = 0, buttons = 0) => ({ pointerId: 1, buttons, point: { x, clone() { return { x }; } } });

--- a/iw3/player/tests/ui-speed.test.mjs
+++ b/iw3/player/tests/ui-speed.test.mjs
@@ -1,0 +1,105 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { fixture, event, Widget, load } from './ui-fixture.mjs';
+
+test('main VR controls provide minus/plus/reset, live slider and hidden-menu guards', async () => {
+    const { u, cache, UIUtils } = await fixture();
+    const MainMenu = await load('menu_main', 'MainMenu', { UIUtils });
+    const menu = new MainMenu(u, 'NotoSans');
+    menu.speedReadout.props.onClick(event());
+    menu.speedPlus.props.onClick(event());
+    assert.equal(u.playbackSpeed.rate, 1.1);
+    menu.speedMinus.props.onClick(event());
+    assert.equal(u.playbackSpeed.rate, 1);
+    await u.setPlaybackSpeedBounds(.25, 3);
+    menu.speedTrack.props.onPointerMove(event(.5, 1));
+    assert.equal(u.playbackSpeed.rate, 3);
+    menu.speedTrack.props.onPointerUp(event());
+    assert.equal(cache.playback_speed.rate, 3);
+    menu.sync({});
+    assert.equal(menu.speedValueText.props.text, 'Speed 3.0x');
+    assert.equal(menu.speedThumb.props.marginLeft, 216);
+    menu.speedReset.props.onClick(event());
+    assert.equal(u.playbackSpeed.rate, 1);
+    menu.speedTrack.props.onClick(event(-.5));
+    assert.equal(u.playbackSpeed.rate, .25);
+    u.visible = false;
+    menu.speedPlus.props.onClick(event());
+    menu.speedReset.props.onClick(event());
+    menu.speedTrack.props.onPointerMove(event(.5, 1));
+    assert.equal(u.playbackSpeed.rate, .25);
+});
+
+test('Render Settings has no speed options and reset/sync never touches speed', async () => {
+    const { u, UIUtils, storage } = await fixture();
+    const RenderSettingsMenu = await load('menu_render_settings', 'RenderSettingsMenu', { UIUtils, storage });
+    const menu = new RenderSettingsMenu(u, 'NotoSans');
+    assert.equal(menu.speedSliders, undefined);
+    assert.equal(menu.speedBoundsText, undefined);
+    const calls = [];
+    u.onSliderChange = (id, value) => calls.push([id, value]);
+    delete u.playbackSpeed;
+    menu.sync();
+    menu.reset();
+    assert.equal(calls.length, 5);
+    assert.ok(calls.every(([id]) => id.startsWith('render_')));
+    const text = widget => [widget.props.text || '', ...widget.children.map(text)].join(' ');
+    assert.doesNotMatch(text(menu.container), /speed|audio support/i);
+});
+
+test('unsupported native rate preserves previous actual speed outside bounds without retry loops', async () => {
+    const { u, cache } = await fixture();
+    let actualRate = 1.7;
+    let attempts = 0;
+    u.stereoPlayer.videoElement = {
+        get playbackRate() { return actualRate; },
+        set playbackRate(rate) { attempts++; if (rate < .0625 || rate > 16) throw new Error('Unsupported'); actualRate = rate; },
+        defaultPlaybackRate: 1.7
+    };
+    await u.setPlaybackSpeed(1.7);
+    await u.setPlaybackSpeedBounds(32, 100);
+    assert.equal(u.playbackSpeed.rate, 1.7);
+    assert.equal(actualRate, 1.7);
+    assert.deepEqual(cache.playback_speed, {min: 32, max: 100, rate: 1.7});
+    assert.match(u.notification, /unsupported/i);
+    const before = attempts;
+    u.applyPlaybackSpeed();
+    assert.equal(attempts, before + 1, 'one application, no fallback/clamp recursion');
+    assert.equal(actualRate, 1.7);
+    await u.resetPlaybackSpeed();
+    assert.deepEqual(cache.playback_speed, {min: 1, max: 100, rate: 1});
+});
+
+test('manager persists exact live bounds, rounds slider only, reloads settings and expands 1x reset', async () => {
+    const { u, cache } = await fixture();
+    await u.setPlaybackSpeed(1.6);
+    assert.equal(u.stereoPlayer.videoElement.playbackRate, 1.6);
+    assert.deepEqual(cache.playback_speed, {min: .1, max: 16, rate: 1.6});
+    await u.handlePlaybackSpeed(event(-.5), new Widget(), false);
+    assert.equal(u.playbackSpeed.rate, .1);
+    assert.equal(cache.playback_speed.rate, 1.6);
+    await u.setPlaybackSpeedBounds(.0625, 1.2345);
+    await u.handlePlaybackSpeed(event(-.5), new Widget());
+    assert.equal(u.playbackSpeed.rate, .0625, 'exact minimum even when slider rounds');
+    await u.handlePlaybackSpeed(event(.5), new Widget());
+    assert.equal(u.playbackSpeed.rate, 1.2345, 'exact maximum even when slider rounds');
+    await u.handlePlaybackSpeed(event(0), new Widget());
+    assert.equal(u.playbackSpeed.rate, .65);
+    assert.equal(await u.setPlaybackSpeedBounds(0, 2), false);
+    assert.equal(u.playbackSpeed.min, .0625);
+    await u.setPlaybackSpeedBounds(.01, .25);
+    await u.resetPlaybackSpeed();
+    assert.deepEqual(cache.playback_speed, {min: .01, max: 1, rate: 1});
+    await u.setPlaybackSpeedBounds(2.12345, 32);
+    await u.resetPlaybackSpeed();
+    assert.deepEqual(cache.playback_speed, {min: 1, max: 32, rate: 1});
+    u.playbackSpeed.setRate(8);
+    await u.loadSettings();
+    assert.equal(u.playbackSpeed.rate, 1);
+    assert.equal(u.stereoPlayer.videoElement.playbackRate, 1);
+    u.visible = false;
+    await u.handlePlaybackSpeed(event(.5), new Widget());
+    assert.equal(u.playbackSpeed.rate, 1);
+    await u.saveSettings();
+    assert.deepEqual(cache.playback_speed, {min: 1, max: 32, rate: 1});
+});


### PR DESCRIPTION
**Written by Hermes–GPT-6 (AI assistant).** Code and automated checks were produced by the assistant. The user tested the controls in Quest Browser and reports that they work well for their use case; this is not a claim of universal browser or audio-quality coverage.

## Motivation

The user wanted playback-speed control while watching in a headset, without adding a full control row to the main menu. This adds a small speed readout that opens a separate popup by normal click, VR trigger, or right-click.

## Behavior

- Slider, proportional +/- (multiply/divide by 1.1), 1x reset and restore-defaults button.
- Default range 0.1–16x; editable bounds 0.01–100x. Min/Max fields offer an in-world numeric keypad and physical-keyboard editing; tapping one also selects that bound as the speed.
- Bound edits apply on OK/Enter without reloading. Speed and bounds persist separately from per-file settings and are reapplied on media changes.
- Unsupported native playback-rate assignments keep the previous actual rate and show a notification. Configurable bounds do not imply browser support; extreme rates can mute audio.
- No speed options added to Render Settings. Keyboard capture is limited to active numeric editing. Pitch preservation is requested where supported.

![Playback-speed popup rendered in a local test scene](https://raw.githubusercontent.com/AscendancyDotA/nunif/9bdb31bccdaaac1837829d9d811efa5fa115796d/docs/iw3-player-speed.png)

The screenshot uses the real player controls in a local test scene, not a headset capture.

## Verification

- From `iw3/player`: `node --test` (or `npm test`) — 15 passing tests covering state, controls, persistence boundaries, keypad/keyboard input, rate rejection and media replacement. UI/GPU/DB boundaries are doubled in these portable tests.
- Additional local Chrome checks exercised rendered pointer controls, real IndexedDB, native media-clock advancement with a synthetic muted clip, and full-app startup. These browser harnesses are not included as portable CI.

Targets `dev` independently of the certificate fix discussed in #731. No Torch repair, installer changes, or fork-specific documentation is included. Feedback on the interaction design or a smaller preferred scope is welcome.
